### PR TITLE
feat: POST CRUD 구현  [ISSUE-25]

### DIFF
--- a/back-end/legeno-around-here/build.gradle
+++ b/back-end/legeno-around-here/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+    testImplementation 'io.rest-assured:rest-assured:3.3.0'
 }
 
 test {

--- a/back-end/legeno-around-here/build.gradle
+++ b/back-end/legeno-around-here/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
-    testImplementation 'io.rest-assured:rest-assured:3.3.0'
+    testImplementation 'io.rest-assured:rest-assured'
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
     testCompileOnly 'org.projectlombok:lombok'

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/GlobalExceptionHandler.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/GlobalExceptionHandler.java
@@ -6,13 +6,21 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import wooteco.team.ittabi.legenoaroundhere.dto.ErrorResponse;
+import wooteco.team.ittabi.legenoaroundhere.exception.NotExistsException;
+import wooteco.team.ittabi.legenoaroundhere.exception.UserInputException;
 
 @RestControllerAdvice(annotations = RestController.class)
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleNotFound(IllegalArgumentException e) {
+    @ExceptionHandler(NotExistsException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(NotExistsException e) {
         return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(UserInputException.class)
+    public ResponseEntity<ErrorResponse> HandleBadRequest(UserInputException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(new ErrorResponse(e.getMessage()));
     }
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/GlobalExceptionHandler.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/GlobalExceptionHandler.java
@@ -14,19 +14,22 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(NotExistsException.class)
     public ResponseEntity<ErrorResponse> handleNotFound(NotExistsException e) {
-        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+        return ResponseEntity
+            .status(HttpStatus.NOT_FOUND)
             .body(new ErrorResponse(e.getMessage()));
     }
 
     @ExceptionHandler(UserInputException.class)
     public ResponseEntity<ErrorResponse> HandleBadRequest(UserInputException e) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity
+            .status(HttpStatus.BAD_REQUEST)
             .body(new ErrorResponse(e.getMessage()));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleInternalServerError() {
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        return ResponseEntity
+            .status(HttpStatus.INTERNAL_SERVER_ERROR)
             .body(new ErrorResponse("예기치 않은 오류가 발생하였습니다."));
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/GlobalExceptionHandler.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package wooteco.team.ittabi.legenoaroundhere.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import wooteco.team.ittabi.legenoaroundhere.dto.ErrorResponse;
+
+@RestControllerAdvice(annotations = RestController.class)
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<ErrorResponse> handleNotFound(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+            .body(new ErrorResponse(e.getMessage()));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleInternalServerError() {
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+            .body(new ErrorResponse("예기치 않은 오류가 발생하였습니다."));
+    }
+}

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
@@ -7,16 +7,17 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import wooteco.team.ittabi.legenoaroundhere.dto.PostCreateRequest;
+import wooteco.team.ittabi.legenoaroundhere.dto.PostRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostResponse;
 
 @RestController
 public class PostController {
 
     @PostMapping("/posts")
-    public ResponseEntity<Void> createPost(@RequestBody PostCreateRequest postCreateRequest) {
+    public ResponseEntity<Void> createPost(@RequestBody PostRequest postRequest) {
         return ResponseEntity.created(URI.create("/posts/1")).build();
     }
 
@@ -24,6 +25,12 @@ public class PostController {
     public ResponseEntity<PostResponse> findPost(@PathVariable Long id) {
         PostResponse postResponse = new PostResponse(id, "글을 등록합니다.");
         return ResponseEntity.ok().body(postResponse);
+    }
+
+    @PutMapping("/posts/{id}")
+    public ResponseEntity<Void> updatePost(@PathVariable Long id,
+        @RequestBody PostRequest postRequest) {
+        return ResponseEntity.ok().build();
     }
 
     @GetMapping("/posts")

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
@@ -4,38 +4,46 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostResponse;
 
 @RestController
+@RequestMapping("/posts")
 public class PostController {
 
-    @PostMapping("/posts")
+    @PostMapping
     public ResponseEntity<Void> createPost(@RequestBody PostRequest postRequest) {
         return ResponseEntity.created(URI.create("/posts/1")).build();
     }
 
-    @GetMapping("/posts/{id}")
+    @GetMapping("/{id}")
     public ResponseEntity<PostResponse> findPost(@PathVariable Long id) {
         PostResponse postResponse = new PostResponse(id, "글을 등록합니다.");
         return ResponseEntity.ok().body(postResponse);
     }
 
-    @PutMapping("/posts/{id}")
+    @PutMapping("/{id}")
     public ResponseEntity<Void> updatePost(@PathVariable Long id,
         @RequestBody PostRequest postRequest) {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/posts")
+    @GetMapping
     public ResponseEntity<List<PostResponse>> findAllPost() {
         PostResponse postResponse = new PostResponse(1L, "글을 등록합니다.");
         return ResponseEntity.ok().body(Collections.singletonList(postResponse));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deletePost(@PathVariable Long id) {
+        return ResponseEntity.noContent().build();
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
@@ -1,0 +1,26 @@
+package wooteco.team.ittabi.legenoaroundhere.controller;
+
+import java.net.URI;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+import wooteco.team.ittabi.legenoaroundhere.dto.PostCreateRequest;
+import wooteco.team.ittabi.legenoaroundhere.dto.PostResponse;
+
+@RestController
+public class PostController {
+
+    @PostMapping("/posts")
+    public ResponseEntity<Void> createPost(@RequestBody PostCreateRequest postCreateRequest) {
+        return ResponseEntity.created(URI.create("/posts/1")).build();
+    }
+
+    @GetMapping("/posts/{id}")
+    public ResponseEntity<PostResponse> findPost(@PathVariable Long id) {
+        PostResponse postResponse = new PostResponse(id, "글을 등록합니다.");
+        return ResponseEntity.ok().body(postResponse);
+    }
+}

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
@@ -14,13 +14,21 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostResponse;
+import wooteco.team.ittabi.legenoaroundhere.service.PostService;
 
 @RestController
 @RequestMapping("/posts")
 public class PostController {
 
+    private PostService postService;
+
+    public PostController(PostService postService) {
+        this.postService = postService;
+    }
+
     @PostMapping
     public ResponseEntity<Void> createPost(@RequestBody PostRequest postRequest) {
+
         return ResponseEntity.created(URI.create("/posts/1")).build();
     }
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
@@ -1,7 +1,6 @@
 package wooteco.team.ittabi.legenoaroundhere.controller;
 
 import java.net.URI;
-import java.util.Collections;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -20,7 +19,7 @@ import wooteco.team.ittabi.legenoaroundhere.service.PostService;
 @RequestMapping("/posts")
 public class PostController {
 
-    private PostService postService;
+    private final PostService postService;
 
     public PostController(PostService postService) {
         this.postService = postService;
@@ -28,29 +27,32 @@ public class PostController {
 
     @PostMapping
     public ResponseEntity<Void> createPost(@RequestBody PostRequest postRequest) {
-        return ResponseEntity.created(URI.create("/posts/1")).build();
+        Long postId = postService.createPost(postRequest).getId();
+        return ResponseEntity.created(URI.create("/posts/" + postId)).build();
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<PostResponse> findPost(@PathVariable Long id) {
-        PostResponse postResponse = new PostResponse(id, "글을 등록합니다.");
-        return ResponseEntity.ok().body(postResponse);
+        PostResponse post = postService.findPost(id);
+        return ResponseEntity.ok().body(post);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<Void> updatePost(@PathVariable Long id,
         @RequestBody PostRequest postRequest) {
+        postService.updatePost(id, postRequest);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping
     public ResponseEntity<List<PostResponse>> findAllPost() {
-        PostResponse postResponse = new PostResponse(1L, "글을 등록합니다.");
-        return ResponseEntity.ok().body(Collections.singletonList(postResponse));
+        List<PostResponse> posts = postService.findAllPost();
+        return ResponseEntity.ok().body(posts);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deletePost(@PathVariable Long id) {
+        postService.deletePost(id);
         return ResponseEntity.noContent().build();
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
@@ -1,6 +1,8 @@
 package wooteco.team.ittabi.legenoaroundhere.controller;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.List;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -22,5 +24,11 @@ public class PostController {
     public ResponseEntity<PostResponse> findPost(@PathVariable Long id) {
         PostResponse postResponse = new PostResponse(id, "글을 등록합니다.");
         return ResponseEntity.ok().body(postResponse);
+    }
+
+    @GetMapping("/posts")
+    public ResponseEntity<List<PostResponse>> findAllPost() {
+        PostResponse postResponse = new PostResponse(1L, "글을 등록합니다.");
+        return ResponseEntity.ok().body(Collections.singletonList(postResponse));
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
@@ -28,7 +28,6 @@ public class PostController {
 
     @PostMapping
     public ResponseEntity<Void> createPost(@RequestBody PostRequest postRequest) {
-
         return ResponseEntity.created(URI.create("/posts/1")).build();
     }
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/PostController.java
@@ -28,31 +28,41 @@ public class PostController {
     @PostMapping
     public ResponseEntity<Void> createPost(@RequestBody PostRequest postRequest) {
         Long postId = postService.createPost(postRequest).getId();
-        return ResponseEntity.created(URI.create("/posts/" + postId)).build();
+        return ResponseEntity
+            .created(URI.create("/posts/" + postId))
+            .build();
     }
 
     @GetMapping("/{id}")
     public ResponseEntity<PostResponse> findPost(@PathVariable Long id) {
         PostResponse post = postService.findPost(id);
-        return ResponseEntity.ok().body(post);
+        return ResponseEntity
+            .ok()
+            .body(post);
     }
 
     @PutMapping("/{id}")
     public ResponseEntity<Void> updatePost(@PathVariable Long id,
         @RequestBody PostRequest postRequest) {
         postService.updatePost(id, postRequest);
-        return ResponseEntity.ok().build();
+        return ResponseEntity
+            .ok()
+            .build();
     }
 
     @GetMapping
     public ResponseEntity<List<PostResponse>> findAllPost() {
         List<PostResponse> posts = postService.findAllPost();
-        return ResponseEntity.ok().body(posts);
+        return ResponseEntity
+            .ok()
+            .body(posts);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deletePost(@PathVariable Long id) {
         postService.deletePost(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity
+            .noContent()
+            .build();
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/BaseEntity.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/BaseEntity.java
@@ -1,0 +1,59 @@
+package wooteco.team.ittabi.legenoaroundhere.domain;
+
+import java.time.LocalDateTime;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+
+@MappedSuperclass
+public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime modifiedAt;
+
+    protected BaseEntity() {
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public LocalDateTime getModifiedAt() {
+        return modifiedAt;
+    }
+
+    public void setModifiedAt(LocalDateTime modifiedAt) {
+        this.modifiedAt = modifiedAt;
+    }
+
+    @Override
+    public String toString() {
+        return "BaseEntity{" +
+            "id=" + id +
+            ", createdAt=" + createdAt +
+            ", modifiedAt=" + modifiedAt +
+            '}';
+    }
+}

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/BaseEntity.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/BaseEntity.java
@@ -28,24 +28,12 @@ public abstract class BaseEntity {
         return id;
     }
 
-    public void setId(Long id) {
-        this.id = id;
-    }
-
     public LocalDateTime getCreatedAt() {
         return createdAt;
     }
 
-    public void setCreatedAt(LocalDateTime createdAt) {
-        this.createdAt = createdAt;
-    }
-
     public LocalDateTime getModifiedAt() {
         return modifiedAt;
-    }
-
-    public void setModifiedAt(LocalDateTime modifiedAt) {
-        this.modifiedAt = modifiedAt;
     }
 
     @Override

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
@@ -12,6 +12,7 @@ public class Post extends BaseEntity {
     private static final int MAX_LENGTH = 20;
 
     private String writing;
+
     @Enumerated(EnumType.STRING)
     private State state;
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
@@ -9,7 +9,7 @@ import wooteco.team.ittabi.legenoaroundhere.exception.UserInputException;
 @Entity
 public class Post extends BaseEntity {
 
-    private static final int LIMIT_LENGTH = 20;
+    private static final int MAX_LENGTH = 20;
 
     private String writing;
     @Enumerated(EnumType.STRING)
@@ -25,8 +25,8 @@ public class Post extends BaseEntity {
     }
 
     private void validateLength(String writing) {
-        if (writing.length() > LIMIT_LENGTH) {
-            throw new UserInputException(LIMIT_LENGTH + "글자를 초과했습니다!");
+        if (writing.length() > MAX_LENGTH) {
+            throw new UserInputException(MAX_LENGTH + "글자를 초과했습니다!");
         }
     }
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
@@ -23,13 +23,16 @@ public class Post {
         }
     }
 
-
     public Long getId() {
         return id;
     }
 
     public String getWriting() {
         return writing;
+    }
+
+    public void setWriting(String writing) {
+        this.writing = writing;
     }
 
     @Override

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import wooteco.team.ittabi.legenoaroundhere.exception.UserInputException;
 
 @Entity
 public class Post extends BaseEntity {
@@ -25,7 +26,7 @@ public class Post extends BaseEntity {
 
     private void validateLength(String writing) {
         if (writing.length() > LIMIT_LENGTH) {
-            throw new IllegalArgumentException(LIMIT_LENGTH + "글자를 초과했습니다!");
+            throw new UserInputException(LIMIT_LENGTH + "글자를 초과했습니다!");
         }
     }
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
@@ -1,11 +1,19 @@
 package wooteco.team.ittabi.legenoaroundhere.domain;
 
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
 public class Post {
 
     private static final int LIMIT_LENGTH = 20;
 
+    @Id
     private Long id;
     private String writing;
+
+    protected Post() {
+    }
 
     public Post(String writing) {
         validateLength(writing);

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
@@ -1,15 +1,12 @@
 package wooteco.team.ittabi.legenoaroundhere.domain;
 
 import javax.persistence.Entity;
-import javax.persistence.Id;
 
 @Entity
-public class Post {
+public class Post extends BaseEntity {
 
     private static final int LIMIT_LENGTH = 20;
 
-    @Id
-    private Long id;
     private String writing;
 
     protected Post() {
@@ -20,19 +17,10 @@ public class Post {
         this.writing = writing;
     }
 
-    public Post(Long id, String writing) {
-        this.id = id;
-        this.writing = writing;
-    }
-
     private void validateLength(String writing) {
         if (writing.length() > LIMIT_LENGTH) {
             throw new IllegalArgumentException(LIMIT_LENGTH + "글자를 초과했습니다!");
         }
-    }
-
-    public Long getId() {
-        return id;
     }
 
     public String getWriting() {
@@ -46,8 +34,7 @@ public class Post {
     @Override
     public String toString() {
         return "Post{" +
-            "id=" + id +
-            ", writing='" + writing + '\'' +
+            "writing='" + writing + '\'' +
             '}';
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
@@ -2,4 +2,41 @@ package wooteco.team.ittabi.legenoaroundhere.domain;
 
 public class Post {
 
+    private static final int LIMIT_LENGTH = 20;
+
+    private Long id;
+    private String writing;
+
+    public Post(String writing) {
+        validateLength(writing);
+        this.writing = writing;
+    }
+
+    public Post(Long id, String writing) {
+        this.id = id;
+        this.writing = writing;
+    }
+
+    private void validateLength(String writing) {
+        if (writing.length() > LIMIT_LENGTH) {
+            throw new IllegalArgumentException(LIMIT_LENGTH + "글자를 초과했습니다!");
+        }
+    }
+
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getWriting() {
+        return writing;
+    }
+
+    @Override
+    public String toString() {
+        return "Post{" +
+            "id=" + id +
+            ", writing='" + writing + '\'' +
+            '}';
+    }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
@@ -1,5 +1,6 @@
 package wooteco.team.ittabi.legenoaroundhere.domain;
 
+import java.util.Objects;
 import javax.persistence.Entity;
 
 @Entity
@@ -8,6 +9,7 @@ public class Post extends BaseEntity {
     private static final int LIMIT_LENGTH = 20;
 
     private String writing;
+    private State state;
 
     protected Post() {
     }
@@ -15,12 +17,21 @@ public class Post extends BaseEntity {
     public Post(String writing) {
         validateLength(writing);
         this.writing = writing;
+        this.state = State.PUBLISHED;
     }
 
     private void validateLength(String writing) {
         if (writing.length() > LIMIT_LENGTH) {
             throw new IllegalArgumentException(LIMIT_LENGTH + "글자를 초과했습니다!");
         }
+    }
+
+    public boolean isSameState(State state) {
+        return Objects.equals(this.state, state);
+    }
+
+    public boolean isNotSameState(State state) {
+        return !Objects.equals(this.state, state);
     }
 
     public String getWriting() {
@@ -31,10 +42,19 @@ public class Post extends BaseEntity {
         this.writing = writing;
     }
 
+    public State getState() {
+        return state;
+    }
+
+    public void setState(State state) {
+        this.state = state;
+    }
+
     @Override
     public String toString() {
         return "Post{" +
             "writing='" + writing + '\'' +
+            ", state=" + state +
             '}';
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
@@ -2,6 +2,8 @@ package wooteco.team.ittabi.legenoaroundhere.domain;
 
 import java.util.Objects;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 
 @Entity
 public class Post extends BaseEntity {
@@ -9,6 +11,7 @@ public class Post extends BaseEntity {
     private static final int LIMIT_LENGTH = 20;
 
     private String writing;
+    @Enumerated(EnumType.STRING)
     private State state;
 
     protected Post() {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/State.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/State.java
@@ -1,5 +1,6 @@
 package wooteco.team.ittabi.legenoaroundhere.domain;
 
-public class State {
-
+public enum State {
+    DELETED,
+    PUBLISHED
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/ErrorResponse.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/ErrorResponse.java
@@ -1,0 +1,14 @@
+package wooteco.team.ittabi.legenoaroundhere.dto;
+
+public class ErrorResponse {
+
+    private String errorMessage;
+
+    public ErrorResponse(String errorMessage) {
+        this.errorMessage = errorMessage;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+}

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/ErrorResponse.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/ErrorResponse.java
@@ -11,4 +11,11 @@ public class ErrorResponse {
     public String getErrorMessage() {
         return errorMessage;
     }
+
+    @Override
+    public String toString() {
+        return "ErrorResponse{" +
+            "errorMessage='" + errorMessage + '\'' +
+            '}';
+    }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostCreateRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostCreateRequest.java
@@ -1,0 +1,39 @@
+package wooteco.team.ittabi.legenoaroundhere.dto;
+
+import java.util.Objects;
+
+public class PostCreateRequest {
+
+    private String writing;
+
+    public PostCreateRequest() {
+    }
+
+    public String getWriting() {
+        return writing;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PostCreateRequest that = (PostCreateRequest) o;
+        return Objects.equals(writing, that.writing);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(writing);
+    }
+
+    @Override
+    public String toString() {
+        return "PostCreateRequest{" +
+            "writing='" + writing + '\'' +
+            '}';
+    }
+}

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostRequest.java
@@ -2,11 +2,15 @@ package wooteco.team.ittabi.legenoaroundhere.dto;
 
 import java.util.Objects;
 
-public class PostCreateRequest {
+public class PostRequest {
 
     private String writing;
 
-    public PostCreateRequest() {
+    public PostRequest() {
+    }
+
+    public PostRequest(String writing) {
+        this.writing = writing;
     }
 
     public String getWriting() {
@@ -21,7 +25,7 @@ public class PostCreateRequest {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        PostCreateRequest that = (PostCreateRequest) o;
+        PostRequest that = (PostRequest) o;
         return Objects.equals(writing, that.writing);
     }
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostRequest.java
@@ -14,6 +14,10 @@ public class PostRequest {
         this.writing = writing;
     }
 
+    public Post toPost() {
+        return new Post(writing);
+    }
+
     public String getWriting() {
         return writing;
     }
@@ -40,9 +44,5 @@ public class PostRequest {
         return "PostCreateRequest{" +
             "writing='" + writing + '\'' +
             '}';
-    }
-
-    public Post toPost() {
-        return new Post(writing);
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostRequest.java
@@ -1,6 +1,7 @@
 package wooteco.team.ittabi.legenoaroundhere.dto;
 
 import java.util.Objects;
+import wooteco.team.ittabi.legenoaroundhere.domain.Post;
 
 public class PostRequest {
 
@@ -39,5 +40,9 @@ public class PostRequest {
         return "PostCreateRequest{" +
             "writing='" + writing + '\'' +
             '}';
+    }
+
+    public Post toPost() {
+        return new Post(writing);
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostResponse.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostResponse.java
@@ -1,6 +1,8 @@
 package wooteco.team.ittabi.legenoaroundhere.dto;
 
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import wooteco.team.ittabi.legenoaroundhere.domain.Post;
 
 public class PostResponse {
@@ -18,6 +20,12 @@ public class PostResponse {
 
     public static PostResponse of(Post post) {
         return new PostResponse(post.getId(), post.getWriting());
+    }
+
+    public static List<PostResponse> listOf(List<Post> posts) {
+        return posts.stream()
+            .map(PostResponse::of)
+            .collect(Collectors.toList());
     }
 
     public Long getId() {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostResponse.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostResponse.java
@@ -1,6 +1,7 @@
 package wooteco.team.ittabi.legenoaroundhere.dto;
 
 import java.util.Objects;
+import wooteco.team.ittabi.legenoaroundhere.domain.Post;
 
 public class PostResponse {
 
@@ -13,6 +14,10 @@ public class PostResponse {
     public PostResponse(Long id, String writing) {
         this.id = id;
         this.writing = writing;
+    }
+
+    public static PostResponse of(Post post) {
+        return new PostResponse(post.getId(), post.getWriting());
     }
 
     public Long getId() {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostResponse.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostResponse.java
@@ -1,0 +1,51 @@
+package wooteco.team.ittabi.legenoaroundhere.dto;
+
+import java.util.Objects;
+
+public class PostResponse {
+
+    private Long id;
+    private String writing;
+
+    public PostResponse() {
+    }
+
+    public PostResponse(Long id, String writing) {
+        this.id = id;
+        this.writing = writing;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getWriting() {
+        return writing;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PostResponse that = (PostResponse) o;
+        return Objects.equals(id, that.id) &&
+            Objects.equals(writing, that.writing);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, writing);
+    }
+
+    @Override
+    public String toString() {
+        return "PostResponse{" +
+            "id=" + id +
+            ", writing='" + writing + '\'' +
+            '}';
+    }
+}

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/exception/NotExistsException.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/exception/NotExistsException.java
@@ -1,0 +1,8 @@
+package wooteco.team.ittabi.legenoaroundhere.exception;
+
+public class NotExistsException extends IllegalArgumentException {
+
+    public NotExistsException(String message) {
+        super(message);
+    }
+}

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/exception/UserInputException.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/exception/UserInputException.java
@@ -1,0 +1,8 @@
+package wooteco.team.ittabi.legenoaroundhere.exception;
+
+public class UserInputException extends IllegalArgumentException {
+
+    public UserInputException(String message) {
+        super(message);
+    }
+}

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/repository/PostRepository.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/repository/PostRepository.java
@@ -1,0 +1,8 @@
+package wooteco.team.ittabi.legenoaroundhere.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import wooteco.team.ittabi.legenoaroundhere.domain.Post;
+
+public interface PostRepository extends JpaRepository<Post, Long> {
+
+}

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
@@ -26,12 +26,17 @@ public class PostService {
     }
 
     public PostResponse findPost(Long id) {
+        Post post = findNotDeletedPost(id);
+        return PostResponse.of(post);
+    }
+
+    private Post findNotDeletedPost(Long id) {
         Post post = postRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 POST가 없습니다."));
         if (post.isSameState(State.DELETED)) {
             throw new IllegalArgumentException("삭제된 POST 입니다!");
         }
-        return PostResponse.of(post);
+        return post;
     }
 
     public List<PostResponse> findAllPost() {
@@ -48,8 +53,7 @@ public class PostService {
     }
 
     public void deletePost(Long id) {
-        Post post = postRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 POST가 없습니다."));
+        Post post = findNotDeletedPost(id);
         post.setState(State.DELETED);
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
@@ -8,6 +8,7 @@ import wooteco.team.ittabi.legenoaroundhere.domain.Post;
 import wooteco.team.ittabi.legenoaroundhere.domain.State;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostResponse;
+import wooteco.team.ittabi.legenoaroundhere.exception.NotExistsException;
 import wooteco.team.ittabi.legenoaroundhere.repository.PostRepository;
 
 @Transactional
@@ -32,9 +33,9 @@ public class PostService {
 
     private Post findNotDeletedPost(Long id) {
         Post post = postRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 POST가 없습니다."));
+            .orElseThrow(() -> new NotExistsException("ID에 해당하는 POST가 없습니다."));
         if (post.isSameState(State.DELETED)) {
-            throw new IllegalArgumentException("삭제된 POST 입니다!");
+            throw new NotExistsException("삭제된 POST 입니다!");
         }
         return post;
     }
@@ -48,7 +49,7 @@ public class PostService {
 
     public void updatePost(Long id, PostRequest postRequest) {
         Post post = postRepository.findById(id)
-            .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 POST가 없습니다."));
+            .orElseThrow(() -> new NotExistsException("ID에 해당하는 POST가 없습니다."));
         post.setWriting(postRequest.getWriting());
     }
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
@@ -1,0 +1,22 @@
+package wooteco.team.ittabi.legenoaroundhere.service;
+
+import org.springframework.stereotype.Service;
+import wooteco.team.ittabi.legenoaroundhere.domain.Post;
+import wooteco.team.ittabi.legenoaroundhere.dto.PostRequest;
+import wooteco.team.ittabi.legenoaroundhere.dto.PostResponse;
+import wooteco.team.ittabi.legenoaroundhere.repository.PostRepository;
+
+@Service
+public class PostService {
+
+    private final PostRepository postRepository;
+
+    public PostService(PostRepository postRepository) {
+        this.postRepository = postRepository;
+    }
+
+    public PostResponse createPost(PostRequest postRequest) {
+        Post post = postRepository.save(postRequest.toPost());
+        return PostResponse.of(post);
+    }
+}

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
@@ -19,4 +19,10 @@ public class PostService {
         Post post = postRepository.save(postRequest.toPost());
         return PostResponse.of(post);
     }
+
+    public PostResponse findPost(Long id) {
+        Post post = postRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 POST가 없습니다."));
+        return PostResponse.of(post);
+    }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
@@ -1,5 +1,6 @@
 package wooteco.team.ittabi.legenoaroundhere.service;
 
+import java.util.List;
 import org.springframework.stereotype.Service;
 import wooteco.team.ittabi.legenoaroundhere.domain.Post;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostRequest;
@@ -24,5 +25,9 @@ public class PostService {
         Post post = postRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 POST가 없습니다."));
         return PostResponse.of(post);
+    }
+
+    public List<PostResponse> findAllPost() {
+        return PostResponse.listOf(postRepository.findAll());
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
@@ -1,12 +1,16 @@
 package wooteco.team.ittabi.legenoaroundhere.service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import wooteco.team.ittabi.legenoaroundhere.domain.Post;
+import wooteco.team.ittabi.legenoaroundhere.domain.State;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostResponse;
 import wooteco.team.ittabi.legenoaroundhere.repository.PostRepository;
 
+@Transactional
 @Service
 public class PostService {
 
@@ -24,11 +28,17 @@ public class PostService {
     public PostResponse findPost(Long id) {
         Post post = postRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 POST가 없습니다."));
+        if (post.isSameState(State.DELETED)) {
+            throw new IllegalArgumentException("삭제된 POST 입니다!");
+        }
         return PostResponse.of(post);
     }
 
     public List<PostResponse> findAllPost() {
-        return PostResponse.listOf(postRepository.findAll());
+        List<Post> posts = postRepository.findAll().stream()
+            .filter(post -> post.isNotSameState(State.DELETED))
+            .collect(Collectors.toList());
+        return PostResponse.listOf(posts);
     }
 
     public void updatePost(Long id, PostRequest postRequest) {
@@ -40,6 +50,6 @@ public class PostService {
     public void deletePost(Long id) {
         Post post = postRepository.findById(id)
             .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 POST가 없습니다."));
-        // TODO: 17/07/2020 Post의 상태를 Enum으로 삭제 상태로 변경
+        post.setState(State.DELETED);
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
@@ -36,4 +36,10 @@ public class PostService {
             .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 POST가 없습니다."));
         post.setWriting(postRequest.getWriting());
     }
+
+    public void deletePost(Long id) {
+        Post post = postRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 POST가 없습니다."));
+        // TODO: 17/07/2020 Post의 상태를 Enum으로 삭제 상태로 변경
+    }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
@@ -30,4 +30,10 @@ public class PostService {
     public List<PostResponse> findAllPost() {
         return PostResponse.listOf(postRepository.findAll());
     }
+
+    public void updatePost(Long id, PostRequest postRequest) {
+        Post post = postRepository.findById(id)
+            .orElseThrow(() -> new IllegalArgumentException("ID에 해당하는 POST가 없습니다."));
+        post.setWriting(postRequest.getWriting());
+    }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.RestAssured;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -52,10 +53,9 @@ public class PostAcceptanceTest {
         assertThat(postResponse.getId()).isEqualTo(id);
         assertThat(postResponse.getWriting()).isEqualTo(expectedWriting);
 
-//         When 글 목록을 조회한다.
-//         Then 글 목록을 응답받는다.
-//         And 글 목록은 n개이다.
-//
+        List<PostResponse> postResponses = findAllPost();
+        assertThat(postResponses).hasSize(1);
+
 //         When 글을 수정한다.
 //         Then 글이 수정되었다.
 //
@@ -66,6 +66,18 @@ public class PostAcceptanceTest {
 //         Then 글이 삭제 상태로 변경된다.
 //         And 다시 글을 조회할 수 없다.
 //         And 글 목록은 n-1개이다.
+    }
+
+    private List<PostResponse> findAllPost() {
+        return given()
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .get("/posts")
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract()
+            .jsonPath()
+            .getList(".", PostResponse.class);
     }
 
     private Long getIdFromUrl(String location) {

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
@@ -45,7 +45,6 @@ public class PostAcceptanceTest {
     @DisplayName("글 관리")
     @Test
     void managePost() {
-
         String expectedWriting = "글을 등록합니다.";
         String location = createPost(expectedWriting);
         Long id = getIdFromUrl(location);

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
@@ -61,10 +61,11 @@ public class PostAcceptanceTest {
         PostResponse updatedPostResponse = findPost(id);
 //        assertThat(updatedPostResponse.getId()).isEqualTo(id);
 //        assertThat(updatedPostResponse.getWriting()).isEqualTo(expectedWriting);
-//
-//         When 글을 조회한다.
-//         Then 글을 응답 받는다.
-//
+
+        PostResponse postFindResponse = findPost(id);
+//        assertThat(postResponse.getId()).isEqualTo(id);
+//        assertThat(postResponse.getWriting()).isEqualTo(writing);
+
 //         When 글을 삭제한다.
 //         Then 글이 삭제 상태로 변경된다.
 //         And 다시 글을 조회할 수 없다.

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
@@ -72,8 +72,8 @@ public class PostAcceptanceTest {
         // 삭제
         deletePost(id);
         findNotExistsPost(id);
-        List<PostResponse> postResponses2 = findAllPost();
-        assertThat(postResponses2).hasSize(0);
+        List<PostResponse> foundPostResponses = findAllPost();
+        assertThat(foundPostResponses).hasSize(0);
     }
 
     private void findNotExistsPost(Long id) {

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
@@ -1,0 +1,103 @@
+package wooteco.team.ittabi.legenoaroundhere.acceptance;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import wooteco.team.ittabi.legenoaroundhere.dto.PostResponse;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class PostAcceptanceTest {
+
+    @LocalServerPort
+    public int port;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+    }
+
+    /**
+     * Feature: 글 관리
+     * <p>
+     * Scenario: 글을 관리한다.
+     * <p>
+     * When 글을 등록한다. Then 글이 등록되었다.
+     * <p>
+     * When 글 목록을 조회한다. Then 글 목록을 응답받는다. And 글 목록은 n개이다.
+     * <p>
+     * When 글을 조회한다. Then 글을 응답 받는다.
+     * <p>
+     * When 글을 수정한다. Then 글이 수정되었다.
+     * <p>
+     * When 글을 삭제한다. Then 글이 삭제 상태로 변경된다. And 다시 글을 조회할 수 없다. And 글 목록은 n-1개이다.
+     */
+    @DisplayName("글 관리")
+    @Test
+    void managePost() {
+
+        String expectedWriting = "글을 등록합니다.";
+        String location = createPost(expectedWriting);
+        Long id = getIdFromUrl(location);
+        PostResponse postResponse = findPost(id);
+        assertThat(postResponse.getId()).isEqualTo(id);
+        assertThat(postResponse.getWriting()).isEqualTo(expectedWriting);
+
+//         When 글 목록을 조회한다.
+//         Then 글 목록을 응답받는다.
+//         And 글 목록은 n개이다.
+//
+//         When 글을 수정한다.
+//         Then 글이 수정되었다.
+//
+//         When 글을 조회한다.
+//         Then 글을 응답 받는다.
+//
+//         When 글을 삭제한다.
+//         Then 글이 삭제 상태로 변경된다.
+//         And 다시 글을 조회할 수 없다.
+//         And 글 목록은 n-1개이다.
+    }
+
+    private Long getIdFromUrl(String location) {
+        int lastIndex = location.lastIndexOf("/");
+        return Long.valueOf(location.substring(lastIndex + 1));
+
+    }
+
+    private PostResponse findPost(Long id) {
+        return given()
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .get("/posts/" + id)
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract()
+            .as(PostResponse.class);
+    }
+
+    private String createPost(String writing) {
+        Map<String, String> params = new HashMap<>();
+        params.put("writing", writing);
+
+        return given()
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .post("/posts")
+            .then()
+            .statusCode(HttpStatus.CREATED.value())
+            .extract()
+            .header("Location");
+    }
+}

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
@@ -66,10 +66,27 @@ public class PostAcceptanceTest {
 //        assertThat(postResponse.getId()).isEqualTo(id);
 //        assertThat(postResponse.getWriting()).isEqualTo(writing);
 
-//         When 글을 삭제한다.
-//         Then 글이 삭제 상태로 변경된다.
-//         And 다시 글을 조회할 수 없다.
-//         And 글 목록은 n-1개이다.
+        deletePost(id);
+//        findNotExistsPost(id);
+        List<PostResponse> postResponses2 = findAllPost();
+//        assertThat(postResponses).hasSize(0);
+    }
+
+    private void findNotExistsPost(Long id) {
+        given()
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .get("/posts/" + id)
+            .then()
+            .statusCode(HttpStatus.NOT_FOUND.value());
+    }
+
+    private void deletePost(Long id) {
+        given()
+            .when()
+            .delete("/posts/" + id)
+            .then()
+            .statusCode(HttpStatus.NO_CONTENT.value());
     }
 
     private void updatePost(Long id, String writing) {

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
@@ -45,6 +45,7 @@ public class PostAcceptanceTest {
     @DisplayName("글 관리")
     @Test
     void managePost() {
+        // 등록
         String expectedWriting = "글을 등록합니다.";
         String location = createPost(expectedWriting);
         Long id = getIdFromUrl(location);
@@ -52,23 +53,27 @@ public class PostAcceptanceTest {
         assertThat(postResponse.getId()).isEqualTo(id);
         assertThat(postResponse.getWriting()).isEqualTo(expectedWriting);
 
+        // 목록 조회
         List<PostResponse> postResponses = findAllPost();
         assertThat(postResponses).hasSize(1);
 
+        // 수정
         String writing = "Hello world!!";
         updatePost(id, writing);
         PostResponse updatedPostResponse = findPost(id);
-//        assertThat(updatedPostResponse.getId()).isEqualTo(id);
-//        assertThat(updatedPostResponse.getWriting()).isEqualTo(expectedWriting);
+        assertThat(updatedPostResponse.getId()).isEqualTo(id);
+        assertThat(updatedPostResponse.getWriting()).isEqualTo(writing);
 
+        // 조회
         PostResponse postFindResponse = findPost(id);
-//        assertThat(postResponse.getId()).isEqualTo(id);
-//        assertThat(postResponse.getWriting()).isEqualTo(writing);
+        assertThat(postFindResponse.getId()).isEqualTo(id);
+        assertThat(postFindResponse.getWriting()).isEqualTo(writing);
 
+        // 삭제
         deletePost(id);
-//        findNotExistsPost(id);
+        findNotExistsPost(id);
         List<PostResponse> postResponses2 = findAllPost();
-//        assertThat(postResponses).hasSize(0);
+        assertThat(postResponses2).hasSize(0);
     }
 
     private void findNotExistsPost(Long id) {

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
@@ -56,8 +56,11 @@ public class PostAcceptanceTest {
         List<PostResponse> postResponses = findAllPost();
         assertThat(postResponses).hasSize(1);
 
-//         When 글을 수정한다.
-//         Then 글이 수정되었다.
+        String writing = "Hello world!!";
+        updatePost(id, writing);
+        PostResponse updatedPostResponse = findPost(id);
+//        assertThat(updatedPostResponse.getId()).isEqualTo(id);
+//        assertThat(updatedPostResponse.getWriting()).isEqualTo(expectedWriting);
 //
 //         When 글을 조회한다.
 //         Then 글을 응답 받는다.
@@ -66,6 +69,19 @@ public class PostAcceptanceTest {
 //         Then 글이 삭제 상태로 변경된다.
 //         And 다시 글을 조회할 수 없다.
 //         And 글 목록은 n-1개이다.
+    }
+
+    private void updatePost(Long id, String writing) {
+        Map<String, String> params = new HashMap<>();
+        params.put("writing", writing);
+
+        given()
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .put("/posts/" + id)
+            .then()
+            .statusCode(HttpStatus.OK.value());
     }
 
     private List<PostResponse> findAllPost() {

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostTest.java
@@ -1,0 +1,15 @@
+package wooteco.team.ittabi.legenoaroundhere.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+public class PostTest {
+
+    @Test
+    void validateLength_OverLength_ThrownException() {
+        String overLengthInput = "aaaaaaaaaaaaaaaaaaaaa";
+        assertThatThrownBy(() -> new Post(overLengthInput))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import wooteco.team.ittabi.legenoaroundhere.exception.UserInputException;
 
 public class PostTest {
 
@@ -13,7 +14,7 @@ public class PostTest {
     void validateLength_OverLength_ThrownException() {
         String overLengthInput = "aaaaaaaaaaaaaaaaaaaaa";
         assertThatThrownBy(() -> new Post(overLengthInput))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(UserInputException.class);
     }
 
     @DisplayName("같은 상태인지 확인")

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostTest.java
@@ -2,10 +2,12 @@ package wooteco.team.ittabi.legenoaroundhere.domain;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class PostTest {
 
+    @DisplayName("길이 검증 - 예외 발생, 기준 길이 초과")
     @Test
     void validateLength_OverLength_ThrownException() {
         String overLengthInput = "aaaaaaaaaaaaaaaaaaaaa";

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostTest.java
@@ -1,5 +1,6 @@
 package wooteco.team.ittabi.legenoaroundhere.domain;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
@@ -7,11 +8,29 @@ import org.junit.jupiter.api.Test;
 
 public class PostTest {
 
-    @DisplayName("길이 검증 - 예외 발생, 기준 길이 초과")
+    @DisplayName("길이 검증 - 예외 발생")
     @Test
     void validateLength_OverLength_ThrownException() {
         String overLengthInput = "aaaaaaaaaaaaaaaaaaaaa";
         assertThatThrownBy(() -> new Post(overLengthInput))
             .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("같은 상태인지 확인")
+    @Test
+    void isSameState_SameState_True() {
+        Post post = new Post("Hello!");
+        post.setState(State.DELETED);
+
+        assertThat(post.isSameState(State.DELETED)).isTrue();
+    }
+
+    @DisplayName("다른 상태인지 확인")
+    @Test
+    void isNotSameState_DifferentState_True() {
+        Post post = new Post("Hello!");
+        post.setState(State.DELETED);
+
+        assertThat(post.isNotSameState(State.PUBLISHED)).isTrue();
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
@@ -1,10 +1,13 @@
 package wooteco.team.ittabi.legenoaroundhere.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -21,21 +24,43 @@ public class PostServiceTest {
     private PostRepository postRepository;
 
     private PostService postService;
-    private Long postId = 1L;
+    private final Long postId = 1L;
+    private final String expectedWriting = "Hello!!";
 
     @BeforeEach
     void setUp() {
         postService = new PostService(postRepository);
     }
 
+    @DisplayName("포스트 생성 - 성공")
     @Test
-    void createPost() {
-        String expectedWriting = "Hello!!";
+    void createPost_SuccessToCreate() {
         PostRequest postRequest = new PostRequest(expectedWriting);
         when(postRepository.save(any())).thenReturn(new Post(postId, expectedWriting));
 
         PostResponse postResponse = postService.createPost(postRequest);
         assertThat(postResponse.getId()).isEqualTo(postId);
         assertThat(postResponse.getWriting()).isEqualTo(expectedWriting);
+    }
+
+    @DisplayName("ID로 포스트 조회 - 성공, ID가 DB에 존재")
+    @Test
+    void findPost_HasId_SuccessToFind() {
+        when(postRepository.findById(any()))
+            .thenReturn(Optional.of(new Post(postId, expectedWriting)));
+
+        PostResponse postResponse = postService.findPost(postId);
+        assertThat(postResponse.getId()).isEqualTo(postId);
+        assertThat(postResponse.getWriting()).isEqualTo(expectedWriting);
+    }
+
+    @DisplayName("ID로 포스트 조회 - 실패, ID가 DB에 없음")
+    @Test
+    void findPost_HasNotId_ThrownException() {
+        when(postRepository.findById(any()))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> postService.findPost(postId))
+            .isInstanceOf(IllegalArgumentException.class);
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
@@ -118,4 +118,16 @@ public class PostServiceTest {
         assertThatThrownBy(() -> postService.deletePost(invalidId))
             .isInstanceOf(IllegalArgumentException.class);
     }
+
+    @DisplayName("삭제한 ID로 포스트 삭제 - 실패")
+    @Test
+    void deletePost_AlreadyDeletedId_ThrownException() {
+        PostRequest createdPostRequest = new PostRequest(expectedWriting);
+        PostResponse createdPostResponse = postService.createPost(createdPostRequest);
+
+        postService.deletePost(createdPostResponse.getId());
+
+        assertThatThrownBy(() -> postService.deletePost(createdPostResponse.getId()))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
@@ -83,4 +83,14 @@ public class PostServiceTest {
             .isInstanceOf(IllegalArgumentException.class);
     }
 
+    @DisplayName("ID로 포스트 삭제처리 - 실패, ID가 DB에 없음")
+    @Test
+    void deletePost_HasId_SuccessToDelete() {
+        when(postRepository.findById(any()))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> postService.deletePost(postId))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
@@ -7,13 +7,13 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostResponse;
 
-@SpringBootTest
-@Transactional
+@DataJpaTest
+@Import(PostService.class)
 public class PostServiceTest {
 
     @Autowired

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
@@ -37,7 +37,9 @@ public class PostServiceTest {
     @Test
     void createPost_SuccessToCreate() {
         PostRequest postRequest = new PostRequest(expectedWriting);
-        when(postRepository.save(any())).thenReturn(new Post(postId, expectedWriting));
+        Post post = new Post(expectedWriting);
+        post.setId(postId);
+        when(postRepository.save(any())).thenReturn(post);
 
         PostResponse postResponse = postService.createPost(postRequest);
         assertThat(postResponse.getId()).isEqualTo(postId);
@@ -47,8 +49,10 @@ public class PostServiceTest {
     @DisplayName("ID로 포스트 조회 - 성공, ID가 DB에 존재")
     @Test
     void findPost_HasId_SuccessToFind() {
+        Post post = new Post(expectedWriting);
+        post.setId(postId);
         when(postRepository.findById(any()))
-            .thenReturn(Optional.of(new Post(postId, expectedWriting)));
+            .thenReturn(Optional.of(post));
 
         PostResponse postResponse = postService.findPost(postId);
         assertThat(postResponse.getId()).isEqualTo(postId);

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,23 +11,15 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostResponse;
-import wooteco.team.ittabi.legenoaroundhere.repository.PostRepository;
 
 @SpringBootTest
 @Transactional
 public class PostServiceTest {
 
     @Autowired
-    private PostRepository postRepository;
-    @Autowired
     private PostService postService;
 
     private final String expectedWriting = "Hello!!";
-
-    @BeforeEach
-    void setUp() {
-        postService = new PostService(postRepository);
-    }
 
     @DisplayName("포스트 생성 - 성공")
     @Test

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
@@ -1,0 +1,41 @@
+package wooteco.team.ittabi.legenoaroundhere.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import wooteco.team.ittabi.legenoaroundhere.domain.Post;
+import wooteco.team.ittabi.legenoaroundhere.dto.PostRequest;
+import wooteco.team.ittabi.legenoaroundhere.dto.PostResponse;
+import wooteco.team.ittabi.legenoaroundhere.repository.PostRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class PostServiceTest {
+
+    @Mock
+    private PostRepository postRepository;
+
+    private PostService postService;
+    private Long postId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        postService = new PostService(postRepository);
+    }
+
+    @Test
+    void createPost() {
+        String expectedWriting = "Hello!!";
+        PostRequest postRequest = new PostRequest(expectedWriting);
+        when(postRepository.save(any())).thenReturn(new Post(postId, expectedWriting));
+
+        PostResponse postResponse = postService.createPost(postRequest);
+        assertThat(postResponse.getId()).isEqualTo(postId);
+        assertThat(postResponse.getWriting()).isEqualTo(expectedWriting);
+    }
+}

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.when;
 
+import java.util.Arrays;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -62,5 +63,12 @@ public class PostServiceTest {
 
         assertThatThrownBy(() -> postService.findPost(postId))
             .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("포스트 전체 목록 조회 - 성공")
+    @Test
+    void findAllPost_SuccessToFind() {
+        when(postRepository.findAll()).thenReturn(Arrays.asList(new Post("hi"), new Post("hihi")));
+        assertThat(postService.findAllPost()).hasSize(2);
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.PostResponse;
+import wooteco.team.ittabi.legenoaroundhere.exception.NotExistsException;
 
 @DataJpaTest
 @Import(PostService.class)
@@ -50,7 +51,7 @@ public class PostServiceTest {
         Long invalidId = -1L;
 
         assertThatThrownBy(() -> postService.findPost(invalidId))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(NotExistsException.class);
     }
 
     @DisplayName("포스트 전체 목록 조회 - 성공")
@@ -86,7 +87,7 @@ public class PostServiceTest {
         Long invalidId = -1L;
 
         assertThatThrownBy(() -> postService.updatePost(invalidId, postRequest))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(NotExistsException.class);
     }
 
     @DisplayName("ID로 포스트 삭제 - 성공")
@@ -98,7 +99,7 @@ public class PostServiceTest {
         postService.deletePost(createdPostResponse.getId());
 
         assertThatThrownBy(() -> postService.findPost(createdPostResponse.getId()))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(NotExistsException.class);
     }
 
     @DisplayName("ID로 포스트 삭제 - 실패")
@@ -107,7 +108,7 @@ public class PostServiceTest {
         Long invalidId = -1L;
 
         assertThatThrownBy(() -> postService.deletePost(invalidId))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(NotExistsException.class);
     }
 
     @DisplayName("삭제한 ID로 포스트 삭제 - 실패")
@@ -119,6 +120,6 @@ public class PostServiceTest {
         postService.deletePost(createdPostResponse.getId());
 
         assertThatThrownBy(() -> postService.deletePost(createdPostResponse.getId()))
-            .isInstanceOf(IllegalArgumentException.class);
+            .isInstanceOf(NotExistsException.class);
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
@@ -71,4 +71,16 @@ public class PostServiceTest {
         when(postRepository.findAll()).thenReturn(Arrays.asList(new Post("hi"), new Post("hihi")));
         assertThat(postService.findAllPost()).hasSize(2);
     }
+
+    @DisplayName("ID로 포스트 수정 - 실패, ID가 DB에 없음")
+    @Test
+    void updatePost_HasNotId_ThrownException() {
+        PostRequest postRequest = new PostRequest(expectedWriting);
+        when(postRepository.findById(any()))
+            .thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> postService.updatePost(postId, postRequest))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
 }


### PR DESCRIPTION
**이슈 번호**

resolved: #25 

**작업 내용**

1. POST CRUD 작성
    - 인수테스트 작성
2. State Enum 추가
    - PUBLISHED : 정상 발행
    - DELETED : 삭제
    - 추후, 임시 저장 or 발행 대기 등으로 확장할 수 있음
    - 확장시 사용여부 YN, 발행여부 YN 등을 필드로 가질 수 있음
3. GlobalExceptionHandler 작성
    - IllegalArgumentException & Exception 처리
4. BaseEntity 분리
    - id, createdAt, modifiedAt 관리
    - 엔티티가 해당 추상클래스를 상속한다면, id, createAt, modifiedAt 필드를 별도로 추가하지 않아도 됨    

**테스트 작성 여부**

- [X] Test case

**참고 사항**
- 추후 논의할 부분
    - 일단 포스트 글자 제한 20자로 했는데, 이 부분은 회의 때 안건 재 상정
    - 해당 PR이 머지된 후 좋아요, 유저 연결, 사진 추가 등을 개발 진행
    - 추후 content (사진, 글 등) 개발할 때, 완전 공란 등의 validation 추가 작업 필요