### PR TITLE
refactor: Jpa Auditing - BaseEntity에 Audit 기능 추가 [ISSUE-60]

### DIFF
--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/LegenoAroundHereApplication.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/LegenoAroundHereApplication.java
@@ -2,7 +2,9 @@ package wooteco.team.ittabi.legenoaroundhere;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class LegenoAroundHereApplication {
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/UserController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/UserController.java
@@ -5,7 +5,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
-import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserCreateRequest;
 import wooteco.team.ittabi.legenoaroundhere.service.UserService;
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/BaseEntity.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/BaseEntity.java
@@ -1,14 +1,17 @@
 package wooteco.team.ittabi.legenoaroundhere.domain;
 
 import java.time.LocalDateTime;
+import javax.persistence.EntityListeners;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.MappedSuperclass;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
 
     @Id

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptanceTest/UserAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptanceTest/UserAcceptanceTest.java
@@ -1,7 +1,14 @@
 package wooteco.team.ittabi.legenoaroundhere.acceptanceTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static wooteco.team.ittabi.legenoaroundhere.constants.UserTestConstants.TEST_EMAIL;
+import static wooteco.team.ittabi.legenoaroundhere.constants.UserTestConstants.TEST_NAME;
+import static wooteco.team.ittabi.legenoaroundhere.constants.UserTestConstants.TEST_PASSWORD;
+
 import io.restassured.RestAssured;
 import io.restassured.specification.RequestSpecification;
+import java.util.HashMap;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -9,12 +16,6 @@ import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import wooteco.team.ittabi.legenoaroundhere.dto.TokenResponse;
-
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static wooteco.team.ittabi.legenoaroundhere.constants.UserTestConstants.*;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class UserAcceptanceTest {

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/controller/UserControllerTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/controller/UserControllerTest.java
@@ -3,7 +3,6 @@ package wooteco.team.ittabi.legenoaroundhere.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -22,7 +21,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 import wooteco.team.ittabi.legenoaroundhere.service.UserService;
 
 @SpringBootTest

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/user/UserTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/user/UserTest.java
@@ -1,17 +1,12 @@
 package wooteco.team.ittabi.legenoaroundhere.domain.user;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static wooteco.team.ittabi.legenoaroundhere.constants.UserTestConstants.TEST_EMAIL;
 import static wooteco.team.ittabi.legenoaroundhere.constants.UserTestConstants.TEST_NAME;
 import static wooteco.team.ittabi.legenoaroundhere.constants.UserTestConstants.TEST_PASSWORD;
 
-import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 class UserTest {
 

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/repository/PostRepositoryTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/repository/PostRepositoryTest.java
@@ -1,15 +1,40 @@
 package wooteco.team.ittabi.legenoaroundhere.repository;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import wooteco.team.ittabi.legenoaroundhere.domain.Post;
+import wooteco.team.ittabi.legenoaroundhere.domain.State;
 
 @DataJpaTest
 class PostRepositoryTest {
 
-    @Test
-    void haha() {
+    @Autowired
+    private PostRepository postRepository;
 
+    @DisplayName("Post 객체 저장")
+    @Test
+    void save() {
+        //given
+        String writing = "writing";
+        Post notSavedPost = new Post(writing);
+        assertThat(notSavedPost.getId()).isNull();
+        assertThat(notSavedPost.getCreatedAt()).isNull();
+        assertThat(notSavedPost.getModifiedAt()).isNull();
+        assertThat(notSavedPost.getWriting()).isEqualTo(writing);
+        assertThat(notSavedPost.getState()).isEqualTo(State.PUBLISHED);
+
+        //when
+        Post savedPost = postRepository.save(notSavedPost);
+
+        //then
+        assertThat(savedPost.getId()).isNotNull();
+        assertThat(savedPost.getCreatedAt()).isNotNull();
+        assertThat(savedPost.getModifiedAt()).isNotNull();
+        assertThat(savedPost.getWriting()).isEqualTo(writing);
+        assertThat(savedPost.getState()).isEqualTo(State.PUBLISHED);
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/repository/PostRepositoryTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/repository/PostRepositoryTest.java
@@ -1,0 +1,15 @@
+package wooteco.team.ittabi.legenoaroundhere.repository;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class PostRepositoryTest {
+
+    @Test
+    void haha() {
+
+    }
+}


### PR DESCRIPTION
**이슈 번호**

resolved: #60

**작업 내용**

1. Audit 관련 어노테이션 추가
2. Audit 기능(@CreatedDate, @LastModifiedDate등)이 잘 수행되는지 확인하기 위해 BaseEntity를 상속하는 Post 객체 save 테스트

**테스트 작성 여부**

- [X] Test case

**주의 사항**
Audit 기능(@CreatedDate, @LastModifiedDate등)을 테스트하기 위해 현재 유일하게 BaseEntity를 상속하는 Post객체로 확인해봤습니다. 이 부분은 이 pr과 관련이 없다고 생각하실 수도 있을 것 같아, 피드백 주시면 수정하도록 하겠습니다.
