### PR TITLE
feat: Area와 Post 엔티티 연관관계 매핑

### DIFF
--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/Post.java
@@ -13,10 +13,12 @@ import javax.persistence.Lob;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import wooteco.team.ittabi.legenoaroundhere.domain.area.Area;
 import wooteco.team.ittabi.legenoaroundhere.domain.sector.Sector;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
@@ -34,29 +36,35 @@ public class Post extends BaseEntity {
     @Column(nullable = false)
     private String writing;
 
-    @Column(nullable = false)
-    @Enumerated(EnumType.STRING)
-    private State state;
-
-    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Comment> comments = new ArrayList<>();
-
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Image> images = new ArrayList<>();
 
     @ManyToOne
-    @JoinColumn(name = "sector_id")
+    @JoinColumn(name = "area_id", nullable = false)
+    private Area area;
+
+    @ManyToOne
+    @JoinColumn(name = "sector_id", nullable = false)
     private Sector sector;
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    private State state;
 
     @ManyToOne
     @JoinColumn(name = "creator_id")
     private User creator;
 
-    public Post(User creator, String writing, Sector sector) {
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    @Builder
+    public Post(String writing, Area area, Sector sector, User creator) {
         validateLength(writing);
         this.writing = writing;
-        this.state = State.PUBLISHED;
+        this.area = area;
         this.sector = sector;
+        this.state = State.PUBLISHED;
         this.creator = creator;
     }
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/area/Area.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/area/Area.java
@@ -3,6 +3,8 @@ package wooteco.team.ittabi.legenoaroundhere.domain.area;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -10,6 +12,8 @@ import wooteco.team.ittabi.legenoaroundhere.domain.BaseEntity;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+@AllArgsConstructor
 @Getter
 @ToString
 public class Area extends BaseEntity {
@@ -30,5 +34,9 @@ public class Area extends BaseEntity {
     private String fourthDepthName;
 
     @Column(nullable = false)
-    private byte used;
+    private Boolean used;
+
+    public boolean isUsed() {
+        return used;
+    }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/AreaResponse.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/AreaResponse.java
@@ -17,6 +17,7 @@ import wooteco.team.ittabi.legenoaroundhere.domain.area.Area;
 @ToString
 public class AreaResponse {
 
+    private Long id;
     private String fullName;
     private String firstDepthName;
     private String secondDepthName;
@@ -25,6 +26,7 @@ public class AreaResponse {
 
     public static AreaResponse of(Area area) {
         return AreaResponse.builder()
+            .id(area.getId())
             .fullName(area.getFullName())
             .firstDepthName(area.getFirstDepthName())
             .secondDepthName(area.getSecondDepthName())

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostCreateRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostCreateRequest.java
@@ -11,6 +11,7 @@ import lombok.Setter;
 import lombok.ToString;
 import org.springframework.web.multipart.MultipartFile;
 import wooteco.team.ittabi.legenoaroundhere.domain.Post;
+import wooteco.team.ittabi.legenoaroundhere.domain.area.Area;
 import wooteco.team.ittabi.legenoaroundhere.domain.sector.Sector;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 
@@ -24,13 +25,19 @@ public class PostCreateRequest {
 
     private String writing;
     private List<MultipartFile> images;
+    private Long areaId;
     private Long sectorId;
 
     public boolean isImagesNull() {
         return Objects.isNull(images);
     }
 
-    public Post toPost(User user, Sector sector) {
-        return new Post(user, writing, sector);
+    public Post toPost(Area area, Sector sector, User user) {
+        return Post.builder()
+            .writing(writing)
+            .area(area)
+            .sector(sector)
+            .creator(user)
+            .build();
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostResponse.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostResponse.java
@@ -23,6 +23,7 @@ public class PostResponse {
     private String writing;
     private List<ImageResponse> images;
     private List<CommentResponse> comments;
+    private AreaResponse area;
     private SectorResponse sector;
     private UserResponse creator;
     private LocalDateTime createdAt;
@@ -34,6 +35,7 @@ public class PostResponse {
             .writing(post.getWriting())
             .images(ImageResponse.listOf(post.getImages()))
             .comments(commentResponses)
+            .area(AreaResponse.of(post.getArea()))
             .sector(SectorResponse.of(post.getSector()))
             .creator(UserResponse.from(post.getCreator()))
             .createdAt(post.getCreatedAt())

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostUpdateRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostUpdateRequest.java
@@ -1,7 +1,6 @@
 package wooteco.team.ittabi.legenoaroundhere.dto;
 
 import java.util.List;
-import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
@@ -10,9 +9,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 import org.springframework.web.multipart.MultipartFile;
-import wooteco.team.ittabi.legenoaroundhere.domain.Post;
-import wooteco.team.ittabi.legenoaroundhere.domain.sector.Sector;
-import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
@@ -24,12 +20,4 @@ public class PostUpdateRequest {
 
     private String writing;
     private List<MultipartFile> images;
-
-    public boolean isImagesNull() {
-        return Objects.isNull(images);
-    }
-
-    public Post toPost(User user, Sector sector) {
-        return new Post(user, writing, null);
-    }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostWithCommentsCountResponse.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostWithCommentsCountResponse.java
@@ -22,8 +22,9 @@ public class PostWithCommentsCountResponse {
     private Long id;
     private String writing;
     private List<ImageResponse> images;
-    private int commentsCount;
+    private AreaResponse area;
     private SectorResponse sector;
+    private int commentsCount;
     private UserResponse creator;
     private LocalDateTime createdAt;
 
@@ -33,8 +34,9 @@ public class PostWithCommentsCountResponse {
             .id(post.getId())
             .writing(post.getWriting())
             .images(ImageResponse.listOf(post.getImages()))
-            .commentsCount(commentResponses.size())
+            .area(AreaResponse.of(post.getArea()))
             .sector(SectorResponse.of(post.getSector()))
+            .commentsCount(commentResponses.size())
             .creator(UserResponse.from(post.getCreator()))
             .createdAt(post.getCreatedAt())
             .build();

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/CommentAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/CommentAcceptanceTest.java
@@ -3,6 +3,7 @@ package wooteco.team.ittabi.legenoaroundhere.acceptance;
 import static io.restassured.RestAssured.given;
 import static io.restassured.config.EncoderConfig.encoderConfig;
 import static org.assertj.core.api.Assertions.assertThat;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AREA_ID;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.PostConstants.TEST_WRITING;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.SectorConstants.TEST_SECTOR_DESCRIPTION;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.SectorConstants.TEST_SECTOR_NAME;
@@ -27,7 +28,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.jdbc.Sql;
 import wooteco.team.ittabi.legenoaroundhere.dto.CommentResponse;
-import wooteco.team.ittabi.legenoaroundhere.dto.PostResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.TokenResponse;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -208,22 +208,11 @@ public class CommentAcceptanceTest {
         return Long.valueOf(location.substring(lastIndex + 1));
     }
 
-    private PostResponse findPost(Long id, String accessToken) {
-        return given()
-            .accept(MediaType.APPLICATION_JSON_VALUE)
-            .header("X-AUTH-TOKEN", accessToken)
-            .when()
-            .get("/posts/" + id)
-            .then()
-            .statusCode(HttpStatus.OK.value())
-            .extract()
-            .as(PostResponse.class);
-    }
-
     private String createPostWithoutImage(String accessToken, Long sectorId) {
         return given()
             .log().all()
             .formParam("writing", TEST_WRITING)
+            .formParam("areaId", TEST_AREA_ID)
             .formParam("sectorId", sectorId)
             .header("X-AUTH-TOKEN", accessToken)
             .config(RestAssuredConfig.config()

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AREA_ID;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.ImageConstants.TEST_IMAGE_DIR;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.PostConstants.TEST_WRITING;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.SectorConstants.TEST_SECTOR_DESCRIPTION;
@@ -94,6 +95,7 @@ public class PostAcceptanceTest {
 
         assertThat(postWithoutImageResponse.getId()).isEqualTo(postWithoutImageId);
         assertThat(postWithoutImageResponse.getWriting()).isEqualTo(TEST_WRITING);
+        assertThat(postWithoutImageResponse.getArea().getId()).isEqualTo(TEST_AREA_ID);
         assertThat(postWithoutImageResponse.getSector()).isEqualTo(sector);
 
         // 이미지가 포함된 글 등록
@@ -105,6 +107,7 @@ public class PostAcceptanceTest {
         assertThat(postWithImageResponse.getId()).isEqualTo(postWithImageId);
         assertThat(postWithImageResponse.getWriting()).isEqualTo(TEST_WRITING);
         assertThat(postWithImageResponse.getImages()).hasSize(2);
+        assertThat(postWithoutImageResponse.getArea().getId()).isEqualTo(TEST_AREA_ID);
         assertThat(postWithoutImageResponse.getSector()).isEqualTo(sector);
 
         // 목록 조회
@@ -361,6 +364,7 @@ public class PostAcceptanceTest {
         return given()
             .log().all()
             .formParam("writing", TEST_WRITING)
+            .formParam("areaId", TEST_AREA_ID)
             .formParam("sectorId", sectorId)
             .header("X-AUTH-TOKEN", accessToken)
             .config(RestAssuredConfig.config()
@@ -380,6 +384,7 @@ public class PostAcceptanceTest {
         return given()
             .log().all()
             .formParam("writing", TEST_WRITING)
+            .formParam("areaId", TEST_AREA_ID)
             .formParam("sectorId", sectorId)
             .header("X-AUTH-TOKEN", accessToken)
             .config(RestAssuredConfig.config()

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/controller/PostControllerTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/controller/PostControllerTest.java
@@ -6,6 +6,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AREA_ID;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.ImageConstants.EMPTY_MULTIPART_FILES;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.SectorConstants.TEST_SECTOR_ID;
 
@@ -63,7 +64,8 @@ public class PostControllerTest {
         doThrow(NotAuthorizedException.class).when(postService).deletePost(any());
 
         String inputJson = objectMapper.writeValueAsString(
-            new PostCreateRequest(EXPECTED_WRITING, EMPTY_MULTIPART_FILES, TEST_SECTOR_ID));
+            new PostCreateRequest(EXPECTED_WRITING, EMPTY_MULTIPART_FILES, TEST_AREA_ID,
+                TEST_SECTOR_ID));
 
         this.mockMvc.perform(delete("/posts/" + ANY_ID)
             .content(inputJson)

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostTest.java
@@ -2,6 +2,12 @@ package wooteco.team.ittabi.legenoaroundhere.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AREA_FIRST_DEPTH_NAME;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AREA_FOURTH_DEPTH_NAME;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AREA_FULL_NAME;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AREA_SECOND_DEPTH_NAME;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AREA_THIRD_DEPTH_NAME;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AREA_USED;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.PostConstants.TEST_WRITING;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.SectorConstants.TEST_SECTOR_DESCRIPTION;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.SectorConstants.TEST_SECTOR_NAME;
@@ -11,6 +17,7 @@ import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import wooteco.team.ittabi.legenoaroundhere.domain.area.Area;
 import wooteco.team.ittabi.legenoaroundhere.domain.sector.Sector;
 import wooteco.team.ittabi.legenoaroundhere.domain.sector.SectorState;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.Email;
@@ -35,18 +42,27 @@ public class PostTest {
         .state(SectorState.PUBLISHED)
         .build();
 
+    private final Area area = Area.builder()
+        .fullName(TEST_AREA_FULL_NAME)
+        .firstDepthName(TEST_AREA_FIRST_DEPTH_NAME)
+        .secondDepthName(TEST_AREA_SECOND_DEPTH_NAME)
+        .thirdDepthName(TEST_AREA_THIRD_DEPTH_NAME)
+        .fourthDepthName(TEST_AREA_FOURTH_DEPTH_NAME)
+        .used(TEST_AREA_USED)
+        .build();
+
     @DisplayName("길이 검증 - 예외 발생")
     @Test
     void validateLength_OverLength_ThrownException() {
         String overLengthInput = "aaaaaaaaaaaaaaaaaaaaa";
-        assertThatThrownBy(() -> new Post(user, overLengthInput, sector))
+        assertThatThrownBy(() -> new Post(overLengthInput, area, sector, user))
             .isInstanceOf(WrongUserInputException.class);
     }
 
     @DisplayName("같은 상태인지 확인")
     @Test
     void isSameState_SameState_True() {
-        Post post = new Post(user, TEST_WRITING, sector);
+        Post post = new Post(TEST_WRITING, area, sector, user);
         post.setState(State.DELETED);
 
         assertThat(post.isSameState(State.DELETED)).isTrue();
@@ -55,7 +71,7 @@ public class PostTest {
     @DisplayName("다른 상태인지 확인")
     @Test
     void isNotSameState_DifferentState_True() {
-        Post post = new Post(user, TEST_WRITING, sector);
+        Post post = new Post(TEST_WRITING, area, sector, user);
         post.setState(State.DELETED);
 
         assertThat(post.isNotSameState(State.PUBLISHED)).isTrue();

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/CommentServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/CommentServiceTest.java
@@ -2,6 +2,7 @@ package wooteco.team.ittabi.legenoaroundhere.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AREA_ID;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.ImageConstants.EMPTY_MULTIPART_FILES;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.PostConstants.TEST_INVALID_POST_ID;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.PostConstants.TEST_WRITING;
@@ -47,8 +48,8 @@ public class CommentServiceTest extends ServiceTest {
         setAuthentication(user);
 
         Long sectorId = sectorService.createSector(TEST_SECTOR_REQUEST).getId();
-        PostCreateRequest postCreateRequest = new PostCreateRequest(TEST_WRITING,
-            EMPTY_MULTIPART_FILES, sectorId);
+        PostCreateRequest postCreateRequest
+            = new PostCreateRequest(TEST_WRITING, EMPTY_MULTIPART_FILES, TEST_AREA_ID, sectorId);
         postResponse = postService.createPost(postCreateRequest);
     }
 

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
@@ -2,6 +2,7 @@ package wooteco.team.ittabi.legenoaroundhere.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AREA_ID;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.ImageConstants.EMPTY_MULTIPART_FILES;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.ImageConstants.TEST_IMAGE_CONTENT_TYPE;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.PostConstants.TEST_INVALID_POST_ID;
@@ -59,7 +60,7 @@ public class PostServiceTest extends ServiceTest {
     @Test
     void createPostWithoutImage_SuccessToCreate() {
         PostCreateRequest postCreateRequest = new PostCreateRequest(TEST_WRITING,
-            EMPTY_MULTIPART_FILES, sectorId);
+            EMPTY_MULTIPART_FILES, TEST_AREA_ID, sectorId);
 
         PostResponse postResponse = postService.createPost(postCreateRequest);
 
@@ -75,7 +76,7 @@ public class PostServiceTest extends ServiceTest {
         MultipartFile multipartFile = FileConverter
             .convert("right_image1.jpg", TEST_IMAGE_CONTENT_TYPE);
         PostCreateRequest postCreateRequest = new PostCreateRequest(TEST_WRITING,
-            Collections.singletonList(multipartFile), sectorId);
+            Collections.singletonList(multipartFile), TEST_AREA_ID, sectorId);
 
         PostResponse postResponse = postService.createPost(postCreateRequest);
 
@@ -89,7 +90,7 @@ public class PostServiceTest extends ServiceTest {
     @Test
     void findPost_HasId_SuccessToFind() {
         PostCreateRequest postCreateRequest = new PostCreateRequest(TEST_WRITING,
-            EMPTY_MULTIPART_FILES, sectorId);
+            EMPTY_MULTIPART_FILES, TEST_AREA_ID, sectorId);
         PostResponse createdPostResponse = postService.createPost(postCreateRequest);
 
         PostResponse postResponse = postService.findPost(createdPostResponse.getId());
@@ -104,7 +105,7 @@ public class PostServiceTest extends ServiceTest {
     @Test
     void findPost_AlreadyDeletedPost_ThrownException() {
         PostCreateRequest postCreateRequest = new PostCreateRequest(TEST_WRITING,
-            EMPTY_MULTIPART_FILES, sectorId);
+            EMPTY_MULTIPART_FILES, TEST_AREA_ID, sectorId);
         PostResponse createdPostResponse = postService.createPost(postCreateRequest);
         postService.deletePost(createdPostResponse.getId());
 
@@ -123,7 +124,7 @@ public class PostServiceTest extends ServiceTest {
     @Test
     void findAllPost_SuccessToFind() {
         PostCreateRequest postCreateRequest = new PostCreateRequest(TEST_WRITING,
-            EMPTY_MULTIPART_FILES, sectorId);
+            EMPTY_MULTIPART_FILES, TEST_AREA_ID, sectorId);
         postService.createPost(postCreateRequest);
         postService.createPost(postCreateRequest);
 
@@ -137,7 +138,7 @@ public class PostServiceTest extends ServiceTest {
     void updatePost_HasId_SuccessToUpdate() {
         String updatedPostWriting = "Jamie and BingBong";
         PostCreateRequest createdPostCreateRequest
-            = new PostCreateRequest(TEST_WRITING, EMPTY_MULTIPART_FILES, sectorId);
+            = new PostCreateRequest(TEST_WRITING, EMPTY_MULTIPART_FILES, TEST_AREA_ID, sectorId);
         PostResponse createdPostResponse = postService.createPost(createdPostCreateRequest);
         PostUpdateRequest postUpdateRequest
             = new PostUpdateRequest(updatedPostWriting, EMPTY_MULTIPART_FILES);
@@ -165,7 +166,7 @@ public class PostServiceTest extends ServiceTest {
     void updatePost_IfNotCreator_ThrowException() {
         String updatedPostWriting = "Jamie and BingBong";
         PostCreateRequest createdPostCreateRequest
-            = new PostCreateRequest(TEST_WRITING, EMPTY_MULTIPART_FILES, sectorId);
+            = new PostCreateRequest(TEST_WRITING, EMPTY_MULTIPART_FILES, TEST_AREA_ID, sectorId);
         PostResponse createdPostResponse = postService.createPost(createdPostCreateRequest);
         PostUpdateRequest postUpdateRequest
             = new PostUpdateRequest(updatedPostWriting, EMPTY_MULTIPART_FILES);
@@ -180,7 +181,7 @@ public class PostServiceTest extends ServiceTest {
     @Test
     void deletePost_HasId_SuccessToDelete() {
         PostCreateRequest createdPostCreateRequest
-            = new PostCreateRequest(TEST_WRITING, EMPTY_MULTIPART_FILES, sectorId);
+            = new PostCreateRequest(TEST_WRITING, EMPTY_MULTIPART_FILES, TEST_AREA_ID, sectorId);
         PostResponse createdPostResponse = postService.createPost(createdPostCreateRequest);
 
         postService.deletePost(createdPostResponse.getId());
@@ -200,7 +201,7 @@ public class PostServiceTest extends ServiceTest {
     @Test
     void deletePost_AlreadyDeletedId_ThrownException() {
         PostCreateRequest createdPostCreateRequest
-            = new PostCreateRequest(TEST_WRITING, EMPTY_MULTIPART_FILES, sectorId);
+            = new PostCreateRequest(TEST_WRITING, EMPTY_MULTIPART_FILES, TEST_AREA_ID, sectorId);
         PostResponse createdPostResponse = postService.createPost(createdPostCreateRequest);
 
         postService.deletePost(createdPostResponse.getId());
@@ -213,7 +214,7 @@ public class PostServiceTest extends ServiceTest {
     @Test
     void deletePost_IfNotCreator_ThrowException() {
         PostCreateRequest createdPostCreateRequest
-            = new PostCreateRequest(TEST_WRITING, EMPTY_MULTIPART_FILES, sectorId);
+            = new PostCreateRequest(TEST_WRITING, EMPTY_MULTIPART_FILES, TEST_AREA_ID, sectorId);
         PostResponse createdPostResponse = postService.createPost(createdPostCreateRequest);
 
         setAuthentication(another);

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/utils/constants/AreaConstants.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/utils/constants/AreaConstants.java
@@ -1,0 +1,12 @@
+package wooteco.team.ittabi.legenoaroundhere.utils.constants;
+
+public class AreaConstants {
+
+    public static final Long TEST_AREA_ID = 1L;
+    public static final String TEST_AREA_FULL_NAME = "AreaFullName";
+    public static final String TEST_AREA_FIRST_DEPTH_NAME = "AreaFirstDepthName";
+    public static final String TEST_AREA_SECOND_DEPTH_NAME = "AreaSecondDepthName";
+    public static final String TEST_AREA_THIRD_DEPTH_NAME = "AreaThirdDepthName";
+    public static final String TEST_AREA_FOURTH_DEPTH_NAME = "AreaFourthDepthName";
+    public static final Boolean TEST_AREA_USED = true;
+}


### PR DESCRIPTION
**이슈 번호**

resolved: #132

**작업 내용**

1. Area와 Post 엔티티 연관관계 매핑
2. Post 응답 dto에 AreaResponse 추가
3. Area의 Used Boolean으로 변경
    - MySQL의 Boolean이 5.* 버전부터 나와서 아닌 예제가 많았나봐요!

**테스트 작성 여부**

- [X] Test case

**주의 사항**
