### PR TITLE
feat: 홈화면 로딩 실패시 403 응답만 login 으로 redirect

### DIFF
--- a/front-end/legeno-around-here/src/components/AppBar.js
+++ b/front-end/legeno-around-here/src/components/AppBar.js
@@ -63,14 +63,20 @@ export default function PrimarySearchAppBar() {
     localStorage.setItem('mainAreaName', '서울특별시');
   }
 
-  const loadAreas = async () => {
+  const loadAreas = () => {
     const accessToken = getAccessTokenFromCookie();
     setLoading(true);
-    const allAreas = await findAllAreas(page, accessToken, areaKeyword);
-    if (allAreas.length === 0) {
-      alert('검색 결과가 없습니다! 다시 검색해주세요!');
-    }
-    setAreas(allAreas);
+    findAllAreas(page, accessToken, areaKeyword)
+      .then(allAreas => {
+        if (allAreas.length === 0) {
+          alert('검색 결과가 없습니다! 다시 검색해주세요!');
+        }
+        setAreas(allAreas);
+      })
+      .catch(errorResponse => {
+        alert('error! F12 참고');
+        console.log(errorResponse);
+      });
     setLoading(false);
   };
 

--- a/front-end/legeno-around-here/src/components/AppBar.js
+++ b/front-end/legeno-around-here/src/components/AppBar.js
@@ -63,20 +63,14 @@ export default function PrimarySearchAppBar() {
     localStorage.setItem('mainAreaName', '서울특별시');
   }
 
-  const loadAreas = () => {
+  const loadAreas = async () => {
     const accessToken = getAccessTokenFromCookie();
     setLoading(true);
-    findAllAreas(page, accessToken, areaKeyword)
-      .then((allAreas) => {
-        if (allAreas.length === 0) {
-          alert('검색 결과가 없습니다! 다시 검색해주세요!');
-        }
-        setAreas(allAreas);
-      })
-      .catch((errorResponse) => {
-        alert('error! F12 참고');
-        console.log(errorResponse);
-      });
+    const allAreas = await findAllAreas(page, accessToken, areaKeyword);
+    if (allAreas.length === 0) {
+      alert('검색 결과가 없습니다! 다시 검색해주세요!');
+    }
+    setAreas(allAreas);
     setLoading(false);
   };
 

--- a/front-end/legeno-around-here/src/components/AppBar.js
+++ b/front-end/legeno-around-here/src/components/AppBar.js
@@ -67,13 +67,13 @@ export default function PrimarySearchAppBar() {
     const accessToken = getAccessTokenFromCookie();
     setLoading(true);
     findAllAreas(page, accessToken, areaKeyword)
-      .then(allAreas => {
+      .then((allAreas) => {
         if (allAreas.length === 0) {
           alert('검색 결과가 없습니다! 다시 검색해주세요!');
         }
         setAreas(allAreas);
       })
-      .catch(errorResponse => {
+      .catch((errorResponse) => {
         alert('error! F12 참고');
         console.log(errorResponse);
       });

--- a/front-end/legeno-around-here/src/components/api/API.js
+++ b/front-end/legeno-around-here/src/components/api/API.js
@@ -1,10 +1,11 @@
 import axios from 'axios';
-import {setAccessTokenCookie} from '../../util/TokenUtils';
+import { setAccessTokenCookie } from '../../util/TokenUtils';
 
 const DEFAULT_SIZE = 10;
 const DEFAULT_SORTED_BY = 'id';
 const DEFAULT_DIRECTION = 'desc';
-const DEFAULT_URL = 'https://back.capzzang.co.kr';
+// const DEFAULT_URL = 'https://back.capzzang.co.kr';
+const DEFAULT_URL = 'http://localhost:8080';
 
 export const loginUser = (email, password, handleReset) => {
   axios
@@ -119,7 +120,7 @@ export const findAllAreas = async (page, accessToken, keyword) => {
       'X-Auth-Token': accessToken,
     },
   };
-  const response = await axios
+  return await axios
     .get(
       DEFAULT_URL +
         `/areas?` +
@@ -130,10 +131,12 @@ export const findAllAreas = async (page, accessToken, keyword) => {
         `keyword=${keyword}`,
       config,
     )
-    .catch(() => {
-      alert(`해당하는 지역이 없습니다!`);
+    .then(response => {
+      return response.data.content;
+    })
+    .catch(error => {
+      throw error.response;
     });
-  return response.data.content;
 };
 
 export const findAllSectors = async (accessToken) => {

--- a/front-end/legeno-around-here/src/components/api/API.js
+++ b/front-end/legeno-around-here/src/components/api/API.js
@@ -1,11 +1,10 @@
 import axios from 'axios';
-import { setAccessTokenCookie } from '../../util/TokenUtils';
+import {setAccessTokenCookie} from '../../util/TokenUtils';
 
 const DEFAULT_SIZE = 10;
 const DEFAULT_SORTED_BY = 'id';
 const DEFAULT_DIRECTION = 'desc';
-// const DEFAULT_URL = 'https://back.capzzang.co.kr';
-const DEFAULT_URL = 'http://localhost:8080';
+const DEFAULT_URL = 'https://back.capzzang.co.kr';
 
 export const loginUser = (email, password, handleReset) => {
   axios
@@ -131,10 +130,10 @@ export const findAllAreas = async (page, accessToken, keyword) => {
         `keyword=${keyword}`,
       config,
     )
-    .then(response => {
+    .then((response) => {
       return response.data.content;
     })
-    .catch(error => {
+    .catch((error) => {
       throw error.response;
     });
 };

--- a/front-end/legeno-around-here/src/components/api/API.js
+++ b/front-end/legeno-around-here/src/components/api/API.js
@@ -92,7 +92,7 @@ export const findCurrentPostsFromPage = async (
       'X-Auth-Token': accessToken,
     },
   };
-  const response = await axios
+  return await axios
     .get(
       DEFAULT_URL +
         `/posts?` +
@@ -104,12 +104,13 @@ export const findCurrentPostsFromPage = async (
         `sectorIds=`,
       config,
     )
+    .then((response) => response.data.content)
     .catch((error) => {
-      console.log(error);
-      console.log(`최근 글을 가져올 수 없습니다! error : ${error}`);
-      document.location.href = '/login';
+      console.log(`## 최근 글을 가져올 수 없습니다.`);
+      console.log(`status code : ${error.response.status}`);
+      console.log(`response 전체 : ${error.response}`);
+      throw error.response;
     });
-  return response.data.content;
 };
 
 export const findAllAreas = async (page, accessToken, keyword) => {

--- a/front-end/legeno-around-here/src/components/pages/Home.js
+++ b/front-end/legeno-around-here/src/components/pages/Home.js
@@ -20,13 +20,19 @@ const Home = () => {
 
   /* 처음에 보여줄 최근글 목록을 가져옴 */
   useEffect(() => {
-    findCurrentPostsFromPage(mainAreaId, 0, accessToken).then((firstPosts) => {
-      if (firstPosts.length === 0) {
-        setHasMore(false);
-        return;
-      }
-      setPosts(firstPosts);
-    });
+    findCurrentPostsFromPage(mainAreaId, 0, accessToken)
+      .then((firstPosts) => {
+        if (firstPosts.length === 0) {
+          setHasMore(false);
+          return;
+        }
+        setPosts(firstPosts);
+      })
+      .catch((errorResponse) => {
+        if (errorResponse.status === 403) {
+          document.location.href = '/login';
+        }
+      });
     setPage(1);
   }, [mainAreaId, accessToken]);
 


### PR DESCRIPTION
**이슈 번호**

resolved: #218 

**작업 내용**

1. 홈화면 로딩 실패시 403 응답만 login 으로 redirect
2. 프론트 에러처리 방식 리팩토링

**테스트 작성 여부**

- [ ] Test case

**주의 사항**
