### PR TITLE
refactor: 홈화면 단일 지역 필터링으로 변경

### DIFF
--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/PostSearch.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/PostSearch.java
@@ -18,12 +18,12 @@ public class PostSearch {
 
     protected static final String DELIMITER = ",";
 
-    private List<Long> areaIds;
+    private Long areaId;
     private List<Long> sectorIds;
 
     @Builder
-    public PostSearch(String areaIds, String sectorIds) {
-        this.areaIds = makeUniqueIds("areaID", areaIds);
+    public PostSearch(Long areaId, String sectorIds) {
+        this.areaId = areaId;
         this.sectorIds = makeUniqueIds("sectorId", sectorIds);
     }
 
@@ -42,14 +42,14 @@ public class PostSearch {
     }
 
     public boolean isAreaFilter() {
-        return !areaIds.isEmpty() && sectorIds.isEmpty();
+        return Objects.nonNull(areaId) && sectorIds.isEmpty();
     }
 
     public boolean isSectorFilter() {
-        return areaIds.isEmpty() && !sectorIds.isEmpty();
+        return Objects.isNull(areaId) && !sectorIds.isEmpty();
     }
 
     public boolean isNotExistsFilter() {
-        return areaIds.isEmpty() && sectorIds.isEmpty();
+        return Objects.isNull(areaId) && sectorIds.isEmpty();
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/area/Area.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/area/Area.java
@@ -1,6 +1,5 @@
 package wooteco.team.ittabi.legenoaroundhere.domain.area;
 
-import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import lombok.AccessLevel;
@@ -49,10 +48,6 @@ public class Area extends BaseEntity {
             return secondDepthName;
         }
         return firstDepthName;
-    }
-
-    public boolean isIncludeId(List<Long> areaIds) {
-        return areaIds.contains(this.getId());
     }
 
     public boolean isSubAreaOf(Area targetArea) {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostSearchRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostSearchRequest.java
@@ -12,12 +12,12 @@ import wooteco.team.ittabi.legenoaroundhere.domain.PostSearch;
 @ToString
 public class PostSearchRequest {
 
-    private String areaIds;
+    private Long areaId;
     private String sectorIds;
 
     public PostSearch toPostSearch() {
         return PostSearch.builder()
-            .areaIds(areaIds)
+            .areaId(areaId)
             .sectorIds(sectorIds)
             .build();
     }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/repository/AreaRepository.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/repository/AreaRepository.java
@@ -1,11 +1,17 @@
 package wooteco.team.ittabi.legenoaroundhere.repository;
 
+import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import wooteco.team.ittabi.legenoaroundhere.domain.area.Area;
 
 public interface AreaRepository extends JpaRepository<Area, Long> {
 
     Page<Area> findAllByFullNameIsLike(Pageable pageable, String keyword);
+
+    @Query(value = "SELECT * FROM area WHERE deleted_at IS NULL AND full_name LIKE (SELECT CONCAT(full_name,'%') FROM area WHERE id = :areaId)", nativeQuery = true)
+    List<Area> findSubAreasById(@Param("areaId") Long areaId);
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
@@ -111,10 +111,11 @@ public class PostService {
     }
 
     private List<Area> findAllAreas(Long areaId) {
-        List<Area> allArea = areaRepository.findAll();
-        Area foundArea = areaRepository.findById(areaId)
-            .orElseThrow(() -> new NotExistsException("해당 Area가 없습니다."));
-        return findSubAreas(allArea, foundArea);
+        List<Area> subAreas = areaRepository.findSubAreasById(areaId);
+        if (subAreas.isEmpty()) {
+            throw new NotExistsException("해당 Area가 존재하지 않습니다.");
+        }
+        return subAreas;
     }
 
     private List<Area> findSubAreas(List<Area> areas, Area targetArea) {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
@@ -1,6 +1,5 @@
 package wooteco.team.ittabi.legenoaroundhere.service;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -97,7 +96,7 @@ public class PostService {
         }
 
         if (postSearch.isAreaFilter()) {
-            List<Area> areas = findAllAreas(postSearch.getAreaIds());
+            List<Area> areas = findAllAreas(postSearch.getAreaId());
             return postRepository.findAllByAreaIn(pageable, areas);
         }
 
@@ -106,31 +105,16 @@ public class PostService {
             return postRepository.findAllBySectorIn(pageable, sectors);
         }
 
-        List<Area> areas = findAllAreas(postSearch.getAreaIds());
+        List<Area> areas = findAllAreas(postSearch.getAreaId());
         List<Sector> sectors = findAllSectors(postSearch.getSectorIds());
         return postRepository.findAllByAreaInAndSectorIn(pageable, areas, sectors);
     }
 
-    private List<Area> findAllAreas(List<Long> areaIds) {
+    private List<Area> findAllAreas(Long areaId) {
         List<Area> allArea = areaRepository.findAll();
-        List<Area> foundArea = findAreas(allArea, areaIds);
-
-        List<Area> areas = new ArrayList<>();
-        for (Area area : foundArea) {
-            areas.addAll(findSubAreas(allArea, area));
-        }
-        return areas;
-    }
-
-    private List<Area> findAreas(List<Area> allArea, List<Long> areaIds) {
-        List<Area> foundArea = allArea.stream()
-            .filter(area -> area.isIncludeId(areaIds))
-            .collect(Collectors.toList());
-
-        if (areaIds.size() != foundArea.size()) {
-            throw new WrongUserInputException("유효하지 않은 Area ID를 사용하셨습니다.");
-        }
-        return foundArea;
+        Area foundArea = areaRepository.findById(areaId)
+            .orElseThrow(() -> new NotExistsException("해당 Area가 없습니다."));
+        return findSubAreas(allArea, foundArea);
     }
 
     private List<Area> findSubAreas(List<Area> areas, Area targetArea) {

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/PostAcceptanceTest.java
@@ -128,15 +128,15 @@ public class PostAcceptanceTest extends AcceptanceTest {
      * <p>
      * Given 글들이 등록되어 있다.
      * <p>
-     * When 글을 areaIds / sectorIds 없이 조회한다. Then 글이 전체 조회되었다.
+     * When 글을 areaId / sectorIds 없이 조회한다. Then 글이 전체 조회되었다.
      * <p>
-     * When 글을 areaIds / sectorIds 값 없이 조회한다. Then 글이 전체 조회되었다.
+     * When 글을 areaId / sectorIds 값 없이 조회한다. Then 글이 전체 조회되었다.
      * <p>
-     * When 글을 areaIds만 포함하여 조회한다. Then areaIds에 해당하는(하위지역 포함) 글들만 조회되었다.
+     * When 글을 areaId만 포함하여 조회한다. Then areaId에 해당하는(하위지역 포함) 글들만 조회되었다.
      * <p>
      * When 글을 sectorIds만 포함하여 조회한다. Then sectorIds에 해당하는 글들만 조회되었다.
      * <p>
-     * When 글을 areaIds, sectorIds를 포함하여 조회한다. Then areaIds, sectorIds에 해당하는(하위지역 포함) 글들만 조회되었다.
+     * When 글을 areaId, sectorIds를 포함하여 조회한다. Then areaId, sectorIds에 해당하는(하위지역 포함) 글들만 조회되었다.
      */
     @DisplayName("글 필터 조회")
     @Test
@@ -161,25 +161,25 @@ public class PostAcceptanceTest extends AcceptanceTest {
         createPostWithoutImageWithAreaAndSector(accessToken, TEST_AREA_OTHER_ID, sectorCId);
         createPostWithoutImageWithAreaAndSector(accessToken, TEST_AREA_OTHER_ID, sectorCId);
 
-        // 글을 areaIds / sectorIds 없이 조회 - 전체
+        // 글을 areaId / sectorIds 없이 조회 - 전체
         List<PostWithCommentsCountResponse> posts = searchAllPost(accessToken);
         assertThat(posts).hasSize(15);
 
-        // 글을 areaIds / sectorIds 값 없이 조회 - 전체
-        posts = searchAllPostWithFilter(accessToken, "areaIds=&sectorIds=");
+        // 글을 areaId / sectorIds 값 없이 조회 - 전체
+        posts = searchAllPostWithFilter(accessToken, "areaId=&sectorIds=");
         assertThat(posts).hasSize(15);
 
-        // 글을 areaIds만 포함하여 조회 - 하위지역 포함 조회
-        posts = searchAllPostWithFilter(accessToken, "areaIds=" + TEST_AREA_ID);
+        // 글을 areaId만 포함하여 조회 - 하위지역 포함 조회
+        posts = searchAllPostWithFilter(accessToken, "areaId=" + TEST_AREA_ID);
         assertThat(posts).hasSize(6);
 
         // 글을 sectorIds만 포함하여 조회
         posts = searchAllPostWithFilter(accessToken, "sectorIds=" + sectorAId + "," + sectorBId);
         assertThat(posts).hasSize(8);
 
-        // 글을 areaIds, sectorIds를 포함하여 조회
+        // 글을 areaId, sectorIds를 포함하여 조회
         posts = searchAllPostWithFilter(accessToken,
-            "areaIds=" + TEST_AREA_ID + "&sectorIds=" + sectorAId + "," + sectorBId);
+            "areaId=" + TEST_AREA_ID + "&sectorIds=" + sectorAId + "," + sectorBId);
         assertThat(posts).hasSize(3);
     }
 

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostSearchTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostSearchTest.java
@@ -5,46 +5,34 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 
 class PostSearchTest {
+
+    protected static final long AREA_ID = 1L;
 
     @DisplayName("생성자에 null 또는 empty가 들어가는 경우 빈 List 필드 생성")
     @Test
     void constructor_NullOrEmpty_IsSizeZero() {
         PostSearch postSearch = new PostSearch(null, null);
 
-        assertThat(postSearch.getAreaIds()).hasSize(0);
-        assertThat(postSearch.getSectorIds()).hasSize(0);
-
-        postSearch = new PostSearch("", null);
-
-        assertThat(postSearch.getAreaIds()).hasSize(0);
+        assertThat(postSearch.getAreaId()).isNull();
         assertThat(postSearch.getSectorIds()).hasSize(0);
 
         postSearch = new PostSearch(null, "");
 
-        assertThat(postSearch.getAreaIds()).hasSize(0);
-        assertThat(postSearch.getSectorIds()).hasSize(0);
-
-        postSearch = new PostSearch("", "");
-
-        assertThat(postSearch.getAreaIds()).hasSize(0);
+        assertThat(postSearch.getAreaId()).isNull();
         assertThat(postSearch.getSectorIds()).hasSize(0);
     }
 
     @DisplayName("생성자에 구분자가 없는 문자열(숫자)이 들어가는 경우")
     @Test
     void constructor_HasNotDelimiterNumber_Success() {
-        String areaIds = "1";
         String sectorIds = "1";
 
-        PostSearch postSearch = new PostSearch(areaIds, sectorIds);
+        PostSearch postSearch = new PostSearch(AREA_ID, sectorIds);
 
-        assertThat(postSearch.getAreaIds()).hasSize(1);
-        assertThat(postSearch.getAreaIds()).contains(Long.valueOf(areaIds));
+        assertThat(postSearch.getAreaId()).isEqualTo(AREA_ID);
         assertThat(postSearch.getSectorIds()).hasSize(1);
         assertThat(postSearch.getSectorIds()).contains(Long.valueOf(sectorIds));
     }
@@ -52,38 +40,38 @@ class PostSearchTest {
     @DisplayName("생성자에 구분자가 있는 문자열(숫자)이 들어가는 경우")
     @Test
     void constructor_HasDelimiterNumber_Success() {
-        String areaIds = "1,2";
         String sectorIds = "1,3,4";
 
-        PostSearch postSearch = new PostSearch(areaIds, sectorIds);
+        PostSearch postSearch = new PostSearch(AREA_ID, sectorIds);
 
-        assertThat(postSearch.getAreaIds()).hasSize(2);
+        assertThat(postSearch.getAreaId()).isEqualTo(AREA_ID);
         assertThat(postSearch.getSectorIds()).hasSize(3);
     }
 
     @DisplayName("생성자에 올바르지 않은 문자열(숫자)이 들어가는 경우")
-    @ParameterizedTest
-    @CsvSource(value = {"ㄱ,1", "1,ㄱ", "ㄱ,ㄱ", "a,1", "1,a", "a,a"})
-    void constructor_WrongIds_Success(String areaIds, String sectorIds) {
-        assertThatThrownBy(() -> new PostSearch("1", "1 "));
-        assertThatThrownBy(() -> new PostSearch(areaIds, sectorIds))
+    @Test
+    void constructor_WrongIds_Success() {
+        assertThatThrownBy(() -> new PostSearch(AREA_ID, "1 "))
+            .isInstanceOf(WrongUserInputException.class);
+
+        assertThatThrownBy(() -> new PostSearch(AREA_ID, "ㄱ"))
             .isInstanceOf(WrongUserInputException.class);
     }
 
-    @DisplayName("AreaIds만 있는 경우, True")
+    @DisplayName("AreaId만 있는 경우, True")
     @Test
-    void isAreaFilter_HasOnlyAreaIds_True() {
-        PostSearch areaFilter = new PostSearch("1", "");
+    void isAreaFilter_HasOnlyAreaId_True() {
+        PostSearch areaFilter = new PostSearch(AREA_ID, "");
 
         assertThat(areaFilter.isAreaFilter()).isTrue();
     }
 
-    @DisplayName("AreaIds만 있는 경우가 아니면, false")
+    @DisplayName("AreaId만 있는 경우가 아니면, false")
     @Test
-    void isAreaFilter_HasOnlyAreaIds_False() {
-        PostSearch noFilter = new PostSearch("", "");
-        PostSearch sectorFilter = new PostSearch("", "1");
-        PostSearch areaAndSectorFilter = new PostSearch("1", "1");
+    void isAreaFilter_HasOnlyAreaId_False() {
+        PostSearch noFilter = new PostSearch(null, "");
+        PostSearch sectorFilter = new PostSearch(null, "1");
+        PostSearch areaAndSectorFilter = new PostSearch(AREA_ID, "1");
 
         assertThat(noFilter.isAreaFilter()).isFalse();
         assertThat(sectorFilter.isAreaFilter()).isFalse();
@@ -93,7 +81,7 @@ class PostSearchTest {
     @DisplayName("SectorIds만 있는 경우, True")
     @Test
     void isSectorFilter_HasOnlySectorIds_True() {
-        PostSearch sectorFilter = new PostSearch("", "1");
+        PostSearch sectorFilter = new PostSearch(null, "1");
 
         assertThat(sectorFilter.isSectorFilter()).isTrue();
     }
@@ -101,31 +89,40 @@ class PostSearchTest {
     @DisplayName("SectorIds만 있는 경우가 아니면, false")
     @Test
     void isSectorFilter_HasNotOnlySectorIds_True() {
-        PostSearch noFilter = new PostSearch("", "");
-        PostSearch areaFilter = new PostSearch("1", "");
-        PostSearch areaAndSectorFilter = new PostSearch("1", "1");
+        PostSearch noFilter = new PostSearch(null, "");
+        PostSearch areaFilter = new PostSearch(AREA_ID, "");
+        PostSearch areaAndSectorFilter = new PostSearch(AREA_ID, "1");
 
         assertThat(noFilter.isSectorFilter()).isFalse();
         assertThat(areaFilter.isSectorFilter()).isFalse();
         assertThat(areaAndSectorFilter.isSectorFilter()).isFalse();
     }
 
-    @DisplayName("SectorIds, AreaIds가 모두 없는 경우, True")
+    @DisplayName("SectorIds, AreaId가 모두 없는 경우, True")
     @Test
     void isSectorFilter_HasNoIds_True() {
-        PostSearch noFilter = new PostSearch("", "");
+        PostSearch noFilter = new PostSearch(null, "");
 
         assertThat(noFilter.isNotExistsFilter()).isTrue();
     }
 
+    @DisplayName("SectorIds, AreaId가 하나라도 있는 경우, False")
     @Test
-    void isNoFilter() {
-        PostSearch areaFilter = new PostSearch("1", "");
-        PostSearch sectorFilter = new PostSearch("", "1");
-        PostSearch areaAndSectorFilter = new PostSearch("1", "1");
+    void isNoFilter_HasIds_False() {
+        PostSearch areaFilter = new PostSearch(AREA_ID, "");
+        PostSearch sectorFilter = new PostSearch(null, "1");
+        PostSearch areaAndSectorFilter = new PostSearch(AREA_ID, "1");
 
         assertThat(areaFilter.isNotExistsFilter()).isFalse();
         assertThat(sectorFilter.isNotExistsFilter()).isFalse();
         assertThat(areaAndSectorFilter.isNotExistsFilter()).isFalse();
+    }
+
+    @DisplayName("SectorIds, AreaId가 모두 없는 경우, True")
+    @Test
+    void isNoFilter_HasNotIds_False() {
+        PostSearch noFilter = new PostSearch(null, "");
+
+        assertThat(noFilter.isNotExistsFilter()).isTrue();
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/repository/AreaRepositoryTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/repository/AreaRepositoryTest.java
@@ -13,6 +13,8 @@ import wooteco.team.ittabi.legenoaroundhere.domain.area.Area;
 class AreaRepositoryTest {
 
     protected static final int INIT_DATA_SIZE = 493;
+    protected static final int SEOUL_SUB_AREA_COUNT = INIT_DATA_SIZE - 1;
+    protected static final long SEOUL_AREA_ID = 1L;
 
     @Autowired
     AreaRepository areaRepository;
@@ -22,5 +24,12 @@ class AreaRepositoryTest {
     void init_checkingArea() {
         List<Area> areas = areaRepository.findAll();
         assertThat(areas).hasSize(INIT_DATA_SIZE);
+    }
+
+    @DisplayName("서울특별시 ID로 검색시 SubAreas 확인")
+    @Test
+    void findAreas_UseAreaId_FoundSubArea() {
+        List<Area> areas = areaRepository.findSubAreasById(SEOUL_AREA_ID);
+        assertThat(areas).hasSize(SEOUL_SUB_AREA_COUNT);
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
@@ -159,12 +159,10 @@ public class PostServiceTest extends ServiceTest {
         postService.createPost(postCreateRequest);
 
         postCreateRequest = new PostCreateRequest(TEST_POST_WRITING,
-            TEST_IMAGE_EMPTY_MULTIPART_FILES,
-            TEST_AREA_OTHER_ID, sectorOtherId);
+            TEST_IMAGE_EMPTY_MULTIPART_FILES, TEST_AREA_OTHER_ID, sectorOtherId);
         postService.createPost(postCreateRequest);
 
-        PostSearchRequest postSearchRequest = new PostSearchRequest(
-            String.valueOf(TEST_AREA_OTHER_ID), null);
+        PostSearchRequest postSearchRequest = new PostSearchRequest(TEST_AREA_OTHER_ID, null);
         Page<PostWithCommentsCountResponse> posts
             = postService.searchAllPost(Pageable.unpaged(), postSearchRequest);
 
@@ -197,8 +195,8 @@ public class PostServiceTest extends ServiceTest {
             TEST_AREA_OTHER_ID, sectorOtherId);
         postService.createPost(postCreateRequest);
 
-        PostSearchRequest postSearchRequest = new PostSearchRequest(
-            String.valueOf(TEST_AREA_OTHER_ID), String.valueOf(sectorOtherId));
+        PostSearchRequest postSearchRequest
+            = new PostSearchRequest(TEST_AREA_OTHER_ID, String.valueOf(sectorOtherId));
         Page<PostWithCommentsCountResponse> posts
             = postService.searchAllPost(Pageable.unpaged(), postSearchRequest);
 

--- a/front-end/legeno-around-here/src/components/api/API.js
+++ b/front-end/legeno-around-here/src/components/api/API.js
@@ -147,7 +147,7 @@ export const findCurrentPostsFromPage = async (
         `size=${DEFAULT_SIZE}&` +
         `sortedBy=${DEFAULT_SORTED_BY}&` +
         `direction=${DEFAULT_DIRECTION}&` +
-        `areaIds=${mainAreaId}&` +
+        `areaId=${mainAreaId}&` +
         `sectorIds=`,
       config,
     )


### PR DESCRIPTION
**이슈 번호**

resolved: #252 

**작업 내용**

1. 홈화면 지역 다중 필터에서 단일 필터로 변경
2. DB로 바로 요청하게끔 변경
    - JPQL로 작업하려 했으나, JPQL은 Where절 서브쿼리를 이용한 LIKE가 불가능하여 NativeQuery로 작업 진행하였습니다.
    - 기대효과 : 홈화면 긴 로딩시간 개선

**테스트 작성 여부**

- [X] Test case

**주의 사항**
