### PR TITLE
feat: User Password 변경 기능 추가 및 기존 변경 기능에서 Password 부분 제거

### DIFF
--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/AwardController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/AwardController.java
@@ -41,7 +41,7 @@ public class AwardController {
             .ok(awards);
     }
 
-    @GetMapping("/awards/my")
+    @GetMapping("/awards/me")
     public ResponseEntity<List<AwardResponse>> findMyAwards() {
         return ResponseEntity
             .ok(awards);

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/UserController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/UserController.java
@@ -13,6 +13,7 @@ import wooteco.team.ittabi.legenoaroundhere.dto.LoginRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.TokenResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserCreateRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserImageResponse;
+import wooteco.team.ittabi.legenoaroundhere.dto.UserPasswordUpdateRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserUpdateRequest;
 import wooteco.team.ittabi.legenoaroundhere.service.UserService;
@@ -43,7 +44,7 @@ public class UserController {
             .ok(token);
     }
 
-    @GetMapping("/users/myinfo")
+    @GetMapping("/users/me")
     public ResponseEntity<UserResponse> findUser() {
         UserResponse user = userService.findUser();
 
@@ -60,18 +61,28 @@ public class UserController {
             .body(userImage);
     }
 
-    @PutMapping("/users/myinfo")
-    public ResponseEntity<UserResponse> updateUser(
+    @PutMapping("/users/me")
+    public ResponseEntity<UserResponse> updateMyInfo(
         @RequestBody UserUpdateRequest userUpdateRequest) {
-        UserResponse user = userService.updateUser(userUpdateRequest);
+        UserResponse user = userService.updateMyInfo(userUpdateRequest);
 
         return ResponseEntity
             .ok(user);
     }
 
-    @DeleteMapping("/users/myinfo")
+    @DeleteMapping("/users/me")
     public ResponseEntity<Void> deleteUser() {
         userService.deleteUser();
+
+        return ResponseEntity
+            .noContent()
+            .build();
+    }
+
+    @PutMapping("/users/me/password")
+    public ResponseEntity<Void> changeMyPassword(
+        @RequestBody UserPasswordUpdateRequest userPasswordUpdateRequest) {
+        userService.changeMyPassword(userPasswordUpdateRequest);
 
         return ResponseEntity
             .noContent()

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/User.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/User.java
@@ -79,6 +79,14 @@ public class User extends BaseEntity implements UserDetails {
         this.image = image;
     }
 
+    public User(String email, String nickname, Area area, UserImage image) {
+        this.email = makeEmail(email);
+        this.nickname = new Nickname(nickname);
+        this.password = null;
+        this.area = area;
+        this.image = image;
+    }
+
     private Email makeEmail(String email) {
         if (Objects.nonNull(email)) {
             return new Email(email);
@@ -86,12 +94,17 @@ public class User extends BaseEntity implements UserDetails {
         return null;
     }
 
-    public void update(User user) {
-        this.nickname = user.nickname;
-        this.password = user.password;
-        this.area = user.area;
-        this.image = user.image;
-        setUserAtImage(user.image);
+    public void setNickname(String nickname) {
+        this.nickname = new Nickname(nickname);
+    }
+
+    public void setPassword(String password) {
+        this.password = new Password(password);
+    }
+
+    public void setImage(UserImage image) {
+        this.image = image;
+        setUserAtImage(image);
     }
 
     private void setUserAtImage(UserImage userImage) {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserAssembler.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserAssembler.java
@@ -4,7 +4,6 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import wooteco.team.ittabi.legenoaroundhere.domain.area.Area;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
-import wooteco.team.ittabi.legenoaroundhere.domain.user.UserImage;
 
 public class UserAssembler {
 
@@ -16,16 +15,6 @@ public class UserAssembler {
             .nickname(userCreateRequest.getNickname())
             .password(PASSWORD_ENCODER.encode(userCreateRequest.getPassword()))
             .area(area)
-            .build();
-    }
-
-    public static User assemble(UserUpdateRequest userUpdateRequest, Area area,
-        UserImage userImage) {
-        return User.builder()
-            .nickname(userUpdateRequest.getNickname())
-            .password(PASSWORD_ENCODER.encode(userUpdateRequest.getPassword()))
-            .area(area)
-            .image(userImage)
             .build();
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserPasswordUpdateRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserPasswordUpdateRequest.java
@@ -14,9 +14,7 @@ import lombok.ToString;
 @Setter
 @EqualsAndHashCode
 @ToString
-public class UserUpdateRequest {
+public class UserPasswordUpdateRequest {
 
-    private String nickname;
-    private Long areaId;
-    private Long imageId;
+    private String password;
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/UserService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/UserService.java
@@ -20,6 +20,7 @@ import wooteco.team.ittabi.legenoaroundhere.dto.TokenResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserAssembler;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserCreateRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserImageResponse;
+import wooteco.team.ittabi.legenoaroundhere.dto.UserPasswordUpdateRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserUpdateRequest;
 import wooteco.team.ittabi.legenoaroundhere.exception.NotExistsException;
@@ -87,16 +88,33 @@ public class UserService implements UserDetailsService {
     }
 
     @Transactional
-    public UserResponse updateUser(UserUpdateRequest userUpdateRequest) {
+    public UserResponse updateMyInfo(UserUpdateRequest userUpdateRequest) {
         User user = (User) authenticationFacade.getPrincipal();
         User foundUser = userRepository.findByEmail(user.getEmail())
             .orElseThrow(() -> new NotExistsException("사용자를 찾을 수 없습니다."));
         Area area = findAreaBy(userUpdateRequest.getAreaId());
         UserImage userImage = findUserImageBy(userUpdateRequest.getImageId());
 
-        foundUser.update(UserAssembler.assemble(userUpdateRequest, area, userImage));
+        foundUser.setNickname(userUpdateRequest.getNickname());
+        foundUser.setArea(area);
+        foundUser.setImage(userImage);
 
         return UserResponse.from(foundUser);
+    }
+
+    @Transactional
+    public void changeMyPassword(UserPasswordUpdateRequest userPasswordUpdateRequest) {
+        User user = (User) authenticationFacade.getPrincipal();
+        User foundUser = userRepository.findByEmail(user.getEmail())
+            .orElseThrow(() -> new NotExistsException("사용자를 찾을 수 없습니다."));
+
+        String password = userPasswordUpdateRequest.getPassword();
+        if (PASSWORD_ENCODER.matches(password, user.getPasswordByString())) {
+            throw new WrongUserInputException("기존의 비밀번호와 동일한 비밀번호입니다.");
+        }
+
+        String encodePassword = PASSWORD_ENCODER.encode(password);
+        foundUser.setPassword(encodePassword);
     }
 
     private UserImage findUserImageBy(Long userImageId) {

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/AwardAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/AwardAcceptanceTest.java
@@ -65,7 +65,7 @@ public class AwardAcceptanceTest extends AcceptanceTest {
             .accept(MediaType.APPLICATION_JSON_VALUE)
             .header("X-AUTH-TOKEN", accessToken)
             .when()
-            .get("/awards/my")
+            .get("/awards/me")
             .then()
             .log().all()
             .statusCode(HttpStatus.OK.value())

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/UserAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/UserAcceptanceTest.java
@@ -247,11 +247,11 @@ public class UserAcceptanceTest extends AcceptanceTest {
             .extract().as(UserResponse.class);
     }
 
-    private UserResponse changeMyPassword(String accessToken, String password) {
+    private void changeMyPassword(String accessToken, String password) {
         Map<String, String> params = new HashMap<>();
         params.put("password", password);
 
-        return given()
+        given()
             .header("X-AUTH-TOKEN", accessToken)
             .body(params)
             .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -259,8 +259,7 @@ public class UserAcceptanceTest extends AcceptanceTest {
             .when()
             .put("/users/me/password")
             .then()
-            .statusCode(HttpStatus.NO_CONTENT.value())
-            .extract().as(UserResponse.class);
+            .statusCode(HttpStatus.NO_CONTENT.value());
     }
 
     private void deleteUser(String accessToken) {

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/controller/UserControllerTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/controller/UserControllerTest.java
@@ -152,7 +152,7 @@ class UserControllerTest {
 
         String expectedJson = objectMapper.writeValueAsString(expected);
 
-        String actual = this.mockMvc.perform(get("/users/myinfo")
+        String actual = this.mockMvc.perform(get("/users/me")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
@@ -165,17 +165,17 @@ class UserControllerTest {
 
     @Test
     @DisplayName("내 정보 수정")
-    void updateUser() throws Exception {
+    void updateMyUser_Success() throws Exception {
         UserResponse expected = UserResponse.builder()
             .id(TEST_USER_ID)
             .email(TEST_USER_EMAIL)
             .nickname(TEST_USER_NICKNAME)
             .build();
-        given(userService.updateUser(any())).willReturn(expected);
+        given(userService.updateMyInfo(any())).willReturn(expected);
 
         String expectedJson = objectMapper.writeValueAsString(expected);
 
-        String actual = this.mockMvc.perform(put("/users/myinfo")
+        String actual = this.mockMvc.perform(put("/users/me")
             .content(expectedJson)
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON))
@@ -190,7 +190,7 @@ class UserControllerTest {
     @Test
     @DisplayName("회원 탈퇴")
     void deleteUser() throws Exception {
-        this.mockMvc.perform(delete("/users/myinfo")
+        this.mockMvc.perform(delete("/users/me")
             .accept(MediaType.APPLICATION_JSON)
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNoContent());

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AREA_ID;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_EMAIL;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_NICKNAME;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_OTHER_PASSWORD;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_PASSWORD;
 
 import org.junit.jupiter.api.DisplayName;
@@ -16,6 +17,7 @@ import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 import wooteco.team.ittabi.legenoaroundhere.dto.LoginRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.TokenResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserCreateRequest;
+import wooteco.team.ittabi.legenoaroundhere.dto.UserPasswordUpdateRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserUpdateRequest;
 import wooteco.team.ittabi.legenoaroundhere.exception.NotExistsException;
@@ -31,8 +33,8 @@ class UserServiceTest extends ServiceTest {
     @Autowired
     private IAuthenticationFacade authenticationFacade;
 
-    @Test
     @DisplayName("User 생성")
+    @Test
     void createUser_Success() {
         UserCreateRequest userCreateRequest =
             new UserCreateRequest(TEST_USER_EMAIL, TEST_USER_NICKNAME, TEST_USER_PASSWORD,
@@ -42,8 +44,8 @@ class UserServiceTest extends ServiceTest {
         assertThat(userId).isNotNull();
     }
 
-    @Test
     @DisplayName("User 생성, 실패 - 중복된 이메일")
+    @Test
     void createUser_DuplicatedEmail_ThrownException() {
         UserCreateRequest userCreateRequest = new UserCreateRequest(TEST_USER_EMAIL,
             TEST_USER_NICKNAME, TEST_USER_PASSWORD, TEST_AREA_ID);
@@ -53,9 +55,9 @@ class UserServiceTest extends ServiceTest {
             .isInstanceOf(WrongUserInputException.class);
     }
 
-    @Test
     @DisplayName("로그인")
-    void login() {
+    @Test
+    void login_Success() {
         UserCreateRequest userCreateRequest =
             new UserCreateRequest(TEST_USER_EMAIL, TEST_USER_NICKNAME, TEST_USER_PASSWORD,
                 TEST_AREA_ID);
@@ -66,16 +68,16 @@ class UserServiceTest extends ServiceTest {
         assertThat(response.getAccessToken()).hasSizeGreaterThan(TOKEN_MIN_SIZE);
     }
 
-    @Test
     @DisplayName("로그인 - 존재하지 않는 이메일")
+    @Test
     void login_IfEmailNotExist_ThrowException() {
         assertThatThrownBy(() -> userService.login(new LoginRequest(TEST_USER_EMAIL,
             TEST_USER_PASSWORD)))
             .isInstanceOf(NotExistsException.class);
     }
 
-    @Test
     @DisplayName("로그인 - 비밀번호가 틀렸을 때")
+    @Test
     void login_IfPasswordIsWrong_ThrowException() {
         UserCreateRequest userCreateRequest = new UserCreateRequest(TEST_USER_EMAIL,
             TEST_USER_NICKNAME, TEST_USER_PASSWORD, TEST_AREA_ID);
@@ -85,9 +87,9 @@ class UserServiceTest extends ServiceTest {
             .isInstanceOf(WrongUserInputException.class);
     }
 
-    @Test
     @DisplayName("email로 User 찾기 (UserDetails 오버라이딩 메서드)")
-    void loadUserByUsername() {
+    @Test
+    void loadUserByUsername_Success() {
         UserCreateRequest userCreateRequest =
             new UserCreateRequest(TEST_USER_EMAIL, TEST_USER_NICKNAME, TEST_USER_PASSWORD,
                 TEST_AREA_ID);
@@ -98,9 +100,9 @@ class UserServiceTest extends ServiceTest {
         assertThat(user.getEmailByString()).isEqualTo(TEST_USER_EMAIL);
     }
 
-    @Test
     @DisplayName("내 정보 찾기")
-    void findUser() {
+    @Test
+    void findUser_Success() {
         User user = createUser(TEST_USER_EMAIL, TEST_USER_NICKNAME, TEST_USER_PASSWORD);
         setAuthentication(user);
 
@@ -108,26 +110,51 @@ class UserServiceTest extends ServiceTest {
         assertThat(userService.findUser().getNickname()).isEqualTo(TEST_USER_NICKNAME);
     }
 
-    @Test
     @DisplayName("내 정보 수정")
-    void updateUser() {
+    @Test
+    void updateMyInfo_Success() {
         User createdUser = createUser(TEST_USER_EMAIL, TEST_USER_NICKNAME, TEST_USER_PASSWORD);
         setAuthentication(createdUser);
         UserUpdateRequest userUpdateRequest
-            = new UserUpdateRequest("newname", "newpassword", TEST_AREA_ID, null);
+            = new UserUpdateRequest("newname", TEST_AREA_ID, null);
 
-        UserResponse updatedUserResponse = userService.updateUser(userUpdateRequest);
+        UserResponse updatedUserResponse = userService.updateMyInfo(userUpdateRequest);
 
         assertThat(updatedUserResponse.getEmail()).isEqualTo(TEST_USER_EMAIL);
         assertThat(updatedUserResponse.getNickname()).isEqualTo("newname");
+    }
 
-        LoginRequest loginRequest = new LoginRequest(TEST_USER_EMAIL, "newpassword");
+    @DisplayName("내 비밀번호 수정, 성공")
+    @Test
+    void changeMyPassword_Success() {
+        User createdUser = createUser(TEST_USER_EMAIL, TEST_USER_NICKNAME, TEST_USER_PASSWORD);
+        setAuthentication(createdUser);
+
+        UserPasswordUpdateRequest userPasswordUpdateRequest
+            = new UserPasswordUpdateRequest(TEST_USER_OTHER_PASSWORD);
+
+        userService.changeMyPassword(userPasswordUpdateRequest);
+
+        LoginRequest loginRequest = new LoginRequest(TEST_USER_EMAIL, TEST_USER_OTHER_PASSWORD);
         assertThat(userService.login(loginRequest)).isInstanceOf(TokenResponse.class);
     }
 
+    @DisplayName("내 비밀번호 수정, 예외 발생 - 기존과 동일한 비밀번호")
     @Test
+    void changeMyPassword_SamePassword_ThrownException() {
+        User createdUser = createUser(TEST_USER_EMAIL, TEST_USER_NICKNAME, TEST_USER_PASSWORD);
+        setAuthentication(createdUser);
+
+        UserPasswordUpdateRequest userPasswordUpdateRequest
+            = new UserPasswordUpdateRequest(TEST_USER_PASSWORD);
+
+        assertThatThrownBy(() -> userService.changeMyPassword(userPasswordUpdateRequest))
+            .isInstanceOf(WrongUserInputException.class);
+    }
+
     @DisplayName("회원 탈퇴")
-    void deleteUser() {
+    @Test
+    void deleteUser_Success() {
         User createdUser = createUser(TEST_USER_EMAIL, TEST_USER_NICKNAME, TEST_USER_PASSWORD);
         setAuthentication(createdUser);
 

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/utils/constants/UserConstants.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/utils/constants/UserConstants.java
@@ -13,4 +13,5 @@ public class UserConstants {
     public static final String TEST_USER_PASSWORD = "testPassword";
 
     public static final String TEST_USER_OTHER_EMAIL = "another@test.com";
+    public static final String TEST_USER_OTHER_PASSWORD = "Password";
 }

--- a/front-end/legeno-around-here/src/components/api/API.js
+++ b/front-end/legeno-around-here/src/components/api/API.js
@@ -142,7 +142,7 @@ export const findMyInfo = ({
     },
   };
   axios
-    .get(DEFAULT_URL + '/users/myinfo', config)
+    .get(DEFAULT_URL + '/users/me', config)
     .then(async (response) => {
       const userResponse = await response.data;
       console.log(userResponse);


### PR DESCRIPTION
**이슈 번호**

resolved: #279 

**작업 내용**

1. User Password 변경 기능 추가
    - 동일한 Password로는 변경이 불가능함
2. 기존 정보 변경 기능에서 Password 변경하던 부분 제거
3. /users/my-info -> /users/me로 Backend 변경 및 Front 변경 (Front 1건 해당)
4. /awards/my -> /awards/me로 Backend 변경(Front에는 해당 URL 존재하지 않았음)

**테스트 작성 여부**

- [X] Test case

**주의 사항**
