### PR TITLE
refactor: 코드 전반 Rombok 적용

### DIFF
--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/aws/S3Uploader.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/aws/S3Uploader.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.Objects;
 import java.util.UUID;
+import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
@@ -17,6 +18,7 @@ import wooteco.team.ittabi.legenoaroundhere.exception.MultipartFileConvertExcept
 
 @Slf4j
 @Component
+@AllArgsConstructor
 public class S3Uploader {
 
     public static final String DIR_DELIMITER = "/";
@@ -24,11 +26,6 @@ public class S3Uploader {
 
     private final AmazonS3 amazonS3Client;
     private final String bucket;
-
-    public S3Uploader(AmazonS3 amazonS3Client, String bucket) {
-        this.amazonS3Client = amazonS3Client;
-        this.bucket = bucket;
-    }
 
     public String upload(MultipartFile multipartFile, String dirName) {
         File uploadFile = convert(multipartFile);

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/aws/S3Uploader.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/aws/S3Uploader.java
@@ -21,7 +21,7 @@ import wooteco.team.ittabi.legenoaroundhere.exception.MultipartFileConvertExcept
 @Slf4j
 public class S3Uploader {
 
-    public static final String FILE_NAME_DELIMITER = "_";
+    private static final String FILE_NAME_DELIMITER = "_";
 
     private final AmazonS3 amazonS3Client;
     private final String bucket;

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/config/SwaggerConfig.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/config/SwaggerConfig.java
@@ -15,8 +15,8 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2;
 @EnableSwagger2
 public class SwaggerConfig {
 
-    public static final String CONTROLLER_PACKAGE_NAME = "wooteco.team.ittabi.legenoaroundhere.controller";
-    public static final String DEFAULT_TITLE = "Legeno Around Here ";
+    private static final String CONTROLLER_PACKAGE_NAME = "wooteco.team.ittabi.legenoaroundhere.controller";
+    private static final String DEFAULT_TITLE = "Legeno Around Here ";
 
     private String groupName;
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/config/WebSecurityConfig.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/config/WebSecurityConfig.java
@@ -16,8 +16,8 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import wooteco.team.ittabi.legenoaroundhere.infra.JwtTokenDecoder;
 
-@AllArgsConstructor
 @EnableWebSecurity
+@AllArgsConstructor
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final JwtTokenDecoder jwtTokenDecoder;

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/AwardController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/AwardController.java
@@ -3,6 +3,7 @@ package wooteco.team.ittabi.legenoaroundhere.controller;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.RestController;
 import wooteco.team.ittabi.legenoaroundhere.dto.AwardResponse;
 
 @RestController
+@AllArgsConstructor
 public class AwardController {
 
     private final static List<AwardResponse> awards = new ArrayList<>();

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/CommentController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/CommentController.java
@@ -35,6 +35,7 @@ public class CommentController {
     public ResponseEntity<Void> createCocomment(@PathVariable Long commentId,
         @RequestBody CommentRequest commentRequest) {
         CommentResponse commentResponse = commentService.createCocomment(commentId, commentRequest);
+
         return ResponseEntity
             .created(URI.create("/comments/" + commentResponse.getId()))
             .build();
@@ -80,6 +81,7 @@ public class CommentController {
     @PostMapping("/comments/{commentId}/zzangs")
     public ResponseEntity<Void> pressCommentZzang(@PathVariable Long commentId) {
         commentService.pressZzang(commentId);
+
         return ResponseEntity
             .noContent()
             .build();

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/GlobalExceptionHandler.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/GlobalExceptionHandler.java
@@ -20,8 +20,8 @@ import wooteco.team.ittabi.legenoaroundhere.exception.NotImageMimeTypeException;
 import wooteco.team.ittabi.legenoaroundhere.exception.NotUniqueException;
 import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 
-@Slf4j
 @RestControllerAdvice(annotations = RestController.class)
+@Slf4j
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(NeedEmailAuthException.class)

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/ProfileController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/ProfileController.java
@@ -8,7 +8,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @AllArgsConstructor
-public class WebController {
+public class ProfileController {
+
+    private static final String PROFILE_NONE = "none";
 
     private final Environment env;
 
@@ -16,6 +18,6 @@ public class WebController {
     public String getProfile() {
         return Arrays.stream(env.getActiveProfiles())
             .findFirst()
-            .orElse("none");
+            .orElse(PROFILE_NONE);
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/BaseEntity.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/BaseEntity.java
@@ -10,7 +10,6 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -20,7 +19,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Setter
 @EqualsAndHashCode(of = "id")
 @ToString
 public abstract class BaseEntity {
@@ -36,4 +34,8 @@ public abstract class BaseEntity {
     private LocalDateTime modifiedAt;
 
     private LocalDateTime deletedAt;
+
+    public void setCreatedAt(LocalDateTime createdAt) {
+        this.createdAt = createdAt;
+    }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/PostSearch.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/PostSearch.java
@@ -46,14 +46,14 @@ public class PostSearch {
     }
 
     public boolean isAreaFilter() {
-        return Objects.nonNull(areaId) && sectorIds.isEmpty();
+        return Objects.nonNull(this.areaId) && this.sectorIds.isEmpty();
     }
 
     public boolean isSectorFilter() {
-        return Objects.isNull(areaId) && !sectorIds.isEmpty();
+        return Objects.isNull(this.areaId) && !this.sectorIds.isEmpty();
     }
 
     public boolean isNotExistsFilter() {
-        return Objects.isNull(areaId) && sectorIds.isEmpty();
+        return Objects.isNull(this.areaId) && this.sectorIds.isEmpty();
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/PostSearch.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/PostSearch.java
@@ -16,7 +16,7 @@ import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 @ToString
 public class PostSearch {
 
-    protected static final String DELIMITER = ",";
+    private static final String DELIMITER = ",";
 
     private final Long areaId;
     private final List<Long> sectorIds;

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/PostSearch.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/PostSearch.java
@@ -24,20 +24,24 @@ public class PostSearch {
     @Builder
     public PostSearch(Long areaId, String sectorIds) {
         this.areaId = areaId;
-        this.sectorIds = makeUniqueIds("sectorId", sectorIds);
+        this.sectorIds = makeSectorIds(sectorIds);
     }
 
-    private List<Long> makeUniqueIds(String name, String ids) {
-        if (Objects.isNull(ids) || ids.isEmpty()) {
+    private List<Long> makeSectorIds(String sectorIds) {
+        if (Objects.isNull(sectorIds) || sectorIds.isEmpty()) {
             return new ArrayList<>();
         }
+        return splitSectorIds(sectorIds);
+    }
+
+    private List<Long> splitSectorIds(String sectorIds) {
         try {
-            return Arrays.stream(ids.split(DELIMITER))
+            return Arrays.stream(sectorIds.split(DELIMITER))
                 .map(Long::valueOf)
                 .distinct()
                 .collect(Collectors.toList());
         } catch (NumberFormatException e) {
-            throw new WrongUserInputException(name + "필터에 올바르지 않은 Id가 입력되었습니다.");
+            throw new WrongUserInputException("sectorIds 필터에 올바르지 않은 Id가 입력되었습니다.");
         }
     }
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/area/Area.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/area/Area.java
@@ -49,8 +49,4 @@ public class Area extends BaseEntity {
         }
         return firstDepthName;
     }
-
-    public boolean isSubAreaOf(Area targetArea) {
-        return this.fullName.startsWith(targetArea.fullName);
-    }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/area/Area.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/area/Area.java
@@ -38,15 +38,15 @@ public class Area extends BaseEntity {
     private String fourthDepthName;
 
     public String getLastDepthName() {
-        if (!fourthDepthName.isEmpty()) {
-            return fourthDepthName;
+        if (!this.fourthDepthName.isEmpty()) {
+            return this.fourthDepthName;
         }
-        if (!thirdDepthName.isEmpty()) {
-            return thirdDepthName;
+        if (!this.thirdDepthName.isEmpty()) {
+            return this.thirdDepthName;
         }
-        if (!secondDepthName.isEmpty()) {
-            return secondDepthName;
+        if (!this.secondDepthName.isEmpty()) {
+            return this.secondDepthName;
         }
-        return firstDepthName;
+        return this.firstDepthName;
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/comment/Comment.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/comment/Comment.java
@@ -3,6 +3,7 @@ package wooteco.team.ittabi.legenoaroundhere.domain.comment;
 import static wooteco.team.ittabi.legenoaroundhere.domain.State.PUBLISHED;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -81,7 +82,7 @@ public class Comment extends BaseEntity {
     public void pressZzang(User user) {
         this.validateAvailable();
         this.post.validateAvailable();
-        Optional<CommentZzang> foundZzang = zzangs.stream()
+        Optional<CommentZzang> foundZzang = this.zzangs.stream()
             .filter(commentZzang -> commentZzang.isSameCreator(user))
             .findFirst();
 
@@ -89,22 +90,21 @@ public class Comment extends BaseEntity {
             this.zzangs.remove(foundZzang.get());
             return;
         }
-        zzangs.add(new CommentZzang(this, user));
+        this.zzangs.add(new CommentZzang(this, user));
     }
 
     private void validateAvailable() {
-        if (!state.isAvailable()) {
+        if (!this.state.isAvailable()) {
             throw new NotAvailableException("ID [" + this.getId() + "]에 해당하는 Comment가 유효하지 않습니다.");
         }
     }
 
     public boolean isAvailable() {
-        return state.isAvailable();
+        return this.state.isAvailable();
     }
 
-    public boolean hasZzangCreator(User user) {
-        return zzangs.stream()
-            .anyMatch(zzang -> zzang.isSameCreator(user));
+    public boolean isNotAvailable() {
+        return !this.state.isAvailable();
     }
 
     public boolean hasPost() {
@@ -112,19 +112,24 @@ public class Comment extends BaseEntity {
     }
 
     public boolean hasSuperComment() {
-        return Objects.isNull(superComment);
+        return Objects.isNull(this.superComment);
     }
 
     public boolean hasCocomments() {
-        return !cocomments.isEmpty();
+        return !this.cocomments.isEmpty();
     }
 
     public boolean hasOnlyCocomment() {
-        return cocomments.size() == 1;
+        return this.cocomments.size() == 1;
+    }
+
+    public boolean hasZzangCreator(User user) {
+        return this.zzangs.stream()
+            .anyMatch(zzang -> zzang.isSameCreator(user));
     }
 
     public int getZzangCounts() {
-        return zzangs.size();
+        return this.zzangs.size();
     }
 
     public void setWriting(String writing) {
@@ -149,7 +154,11 @@ public class Comment extends BaseEntity {
         this.state = state;
     }
 
-    public boolean isNotAvailable() {
-        return !state.isAvailable();
+    public List<Comment> getCocomments() {
+        return Collections.unmodifiableList(this.cocomments);
+    }
+
+    public List<CommentZzang> getZzangs() {
+        return Collections.unmodifiableList(this.zzangs);
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/comment/Comment.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/comment/Comment.java
@@ -32,7 +32,7 @@ import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@ToString(exclude = {"post", "superComment", "cocomments"})
+@ToString(exclude = {"post", "superComment", "cocomments", "zzangs"})
 @SQLDelete(sql = "UPDATE comment SET deleted_at = NOW() WHERE id = ?")
 @Where(clause = "deleted_at IS NULL")
 public class Comment extends BaseEntity {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/comment/CommentZzang.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/comment/CommentZzang.java
@@ -5,6 +5,7 @@ import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -14,6 +15,7 @@ import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @ToString(exclude = {"comment", "creator"})
 public class CommentZzang extends BaseEntity {
 
@@ -24,11 +26,6 @@ public class CommentZzang extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "creator_id", nullable = false)
     private User creator;
-
-    public CommentZzang(Comment comment, User creator) {
-        this.comment = comment;
-        this.creator = creator;
-    }
 
     public boolean isSameCreator(User user) {
         return this.creator.equals(user);

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/post/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/post/Post.java
@@ -86,12 +86,57 @@ public class Post extends BaseEntity {
         }
     }
 
+    public void addPostImages(PostImage postImage) {
+        if (!this.postImages.contains(postImage)) {
+            this.postImages.add(postImage);
+        }
+    }
+
+    public void addComment(Comment comment) {
+        if (!this.comments.contains(comment)) {
+            this.comments.add(comment);
+        }
+        if (!comment.hasPost()) {
+            comment.setPost(this);
+        }
+    }
+
+    public void removeComments(Comment comment) {
+        this.comments.remove(comment);
+    }
+
+    public int getAvailableCommentsSize() {
+        return (int) this.comments.stream()
+            .filter(Comment::isAvailable)
+            .count();
+    }
+
+    public void pressZzang(User user) {
+        validateAvailable();
+        Optional<PostZzang> foundZzang = this.zzangs.stream()
+            .filter(PostZzang -> PostZzang.isSameCreator(user))
+            .findFirst();
+
+        if (foundZzang.isPresent()) {
+            this.zzangs.remove(foundZzang.get());
+            return;
+        }
+        this.zzangs.add(new PostZzang(this, user));
+    }
+
+    public void validateAvailable() {
+        if (!this.state.isAvailable()) {
+            throw new NotAvailableException(
+                "ID [" + this.getId() + "]에 해당하는 Post가 유효하지 않습니다.");
+        }
+    }
+
     public int getPostZzangCount() {
-        return zzangs.size();
+        return this.zzangs.size();
     }
 
     public int getPostZzangCountByDate(LocalDateTime startDate, LocalDateTime endDate) {
-        long zzangCount = zzangs.stream()
+        long zzangCount = this.zzangs.stream()
             .filter(postZzang -> isDateBetween(postZzang.getCreatedAt(), startDate, endDate))
             .count();
         return Math.toIntExact(zzangCount);
@@ -104,59 +149,28 @@ public class Post extends BaseEntity {
     }
 
     public boolean hasZzangCreator(User user) {
-        return zzangs.stream()
+        return this.zzangs.stream()
             .anyMatch(zzang -> zzang.isSameCreator(user));
-    }
-
-    public void addComment(Comment comment) {
-        if (!comments.contains(comment)) {
-            comments.add(comment);
-        }
-        if (!comment.hasPost()) {
-            comment.setPost(this);
-        }
-    }
-
-    public void removeComments(Comment comment) {
-        comments.remove(comment);
-    }
-
-    public List<Comment> getComments() {
-        return Collections.unmodifiableList(comments);
-    }
-
-    public int getAvailableCommentsSize() {
-        return (int) comments.stream()
-            .filter(Comment::isAvailable)
-            .count();
-    }
-
-    public void pressZzang(User user) {
-        validateAvailable();
-        Optional<PostZzang> foundZzang = zzangs.stream()
-            .filter(PostZzang -> PostZzang.isSameCreator(user))
-            .findFirst();
-
-        if (foundZzang.isPresent()) {
-            this.zzangs.remove(foundZzang.get());
-            return;
-        }
-        zzangs.add(new PostZzang(this, user));
-    }
-
-    public void validateAvailable() {
-        if (!this.state.isAvailable()) {
-            throw new NotAvailableException(
-                "ID [" + this.getId() + "]에 해당하는 Post가 유효하지 않습니다.");
-        }
     }
 
     public void setWriting(String writing) {
         this.writing = writing;
     }
 
+    public List<PostImage> getPostImages() {
+        return Collections.unmodifiableList(this.postImages);
+    }
+
     public void setPostImages(List<PostImage> postImages) {
         this.postImages = postImages;
+    }
+
+    public List<PostZzang> getZzangs() {
+        return Collections.unmodifiableList(this.zzangs);
+    }
+
+    public List<Comment> getComments() {
+        return Collections.unmodifiableList(this.comments);
     }
 
     public void setState(State state) {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/post/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/post/Post.java
@@ -18,7 +18,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -35,7 +34,6 @@ import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Setter
 @ToString(exclude = {"comments", "postImages", "zzangs"})
 @SQLDelete(sql = "UPDATE post SET deleted_at = NOW() WHERE id = ?")
 @Where(clause = "deleted_at IS NULL")
@@ -151,5 +149,17 @@ public class Post extends BaseEntity {
             throw new NotAvailableException(
                 "ID [" + this.getId() + "]에 해당하는 Post가 유효하지 않습니다.");
         }
+    }
+
+    public void setWriting(String writing) {
+        this.writing = writing;
+    }
+
+    public void setPostImages(List<PostImage> postImages) {
+        this.postImages = postImages;
+    }
+
+    public void setState(State state) {
+        this.state = state;
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/post/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/post/Post.java
@@ -88,10 +88,6 @@ public class Post extends BaseEntity {
         }
     }
 
-    public boolean isAvailable() {
-        return this.state.isAvailable();
-    }
-
     public int getPostZzangCount() {
         return zzangs.size();
     }
@@ -107,13 +103,6 @@ public class Post extends BaseEntity {
         LocalDateTime endDate) {
         return targetDate.isAfter(startDate)
             && targetDate.isBefore(endDate);
-    }
-
-    public PostZzang findPostZzangBy(User user) {
-        return zzangs.stream()
-            .filter(postZzang -> postZzang.isSameCreator(user))
-            .findFirst()
-            .orElseGet(() -> new PostZzang(this, user));
     }
 
     public boolean hasZzangCreator(User user) {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/post/PostZzang.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/post/PostZzang.java
@@ -6,6 +6,7 @@ import javax.persistence.FetchType;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -15,6 +16,7 @@ import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @ToString(exclude = {"post", "creator"})
 public class PostZzang extends BaseEntity {
 
@@ -25,11 +27,6 @@ public class PostZzang extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "creator_id", nullable = false)
     private User creator;
-
-    public PostZzang(Post post, User creator) {
-        this.post = post;
-        this.creator = creator;
-    }
 
     public boolean isSameCreator(User user) {
         return Objects.equals(this.creator, user);

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/post/image/PostImage.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/post/image/PostImage.java
@@ -47,6 +47,6 @@ public class PostImage extends BaseEntity {
             this.post.getPostImages().remove(this);
         }
         this.post = post;
-        post.getPostImages().add(this);
+        post.addPostImages(this);
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/ranking/RankingCriteria.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/ranking/RankingCriteria.java
@@ -2,6 +2,7 @@ package wooteco.team.ittabi.legenoaroundhere.domain.ranking;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import wooteco.team.ittabi.legenoaroundhere.exception.NotExistsException;
 
 public enum RankingCriteria {
     YESTERDAY("yesterday",
@@ -50,7 +51,7 @@ public enum RankingCriteria {
         return Arrays.stream(values())
             .filter(rc -> rc.isSameRankingCriteria(criteria))
             .findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 랭킹 기준입니다."));
+            .orElseThrow(() -> new NotExistsException("존재하지 않는 랭킹 기준입니다."));
     }
 
     private boolean isSameRankingCriteria(String criteria) {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/sector/Sector.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/sector/Sector.java
@@ -100,7 +100,7 @@ public class Sector extends BaseEntity {
     }
 
     public boolean isUniqueState() {
-        return state.isUnique();
+        return this.state.isUnique();
     }
 
     public String getName() {
@@ -112,11 +112,11 @@ public class Sector extends BaseEntity {
     }
 
     public String getState() {
-        return state.getName();
+        return this.state.getName();
     }
 
     public String getStateExceptionName() {
-        return state.getExceptionName();
+        return this.state.getExceptionName();
     }
 
     public List<Post> getPosts() {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/sector/Sector.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/sector/Sector.java
@@ -32,7 +32,7 @@ import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 @Where(clause = "deleted_at IS NULL")
 public class Sector extends BaseEntity {
 
-    protected static final String DEFAULT_REASON = "";
+    private static final String DEFAULT_REASON = "";
 
     @Embedded
     private Name name;

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/sector/SectorState.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/sector/SectorState.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 
 public enum SectorState {
-
     PUBLISHED("등록", "사용", true, true),
     PENDING("승인 신청", "승인 신청", false, true),
     APPROVED("승인", "사용", true, true),

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/sector/SectorState.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/sector/SectorState.java
@@ -23,31 +23,31 @@ public enum SectorState {
     }
 
     public static SectorState of(String name) {
-        return Arrays.stream(SectorState.values())
+        return Arrays.stream(values())
             .filter(sectorState -> sectorState.getName().equals(name))
             .findFirst()
             .orElseThrow(() -> new WrongUserInputException("Sector 상태를 잘못 입력하셨습니다."));
     }
 
     public static Iterable<SectorState> getAllAvailable() {
-        return Arrays.stream(SectorState.values())
+        return Arrays.stream(values())
             .filter(sector -> sector.used)
             .collect(Collectors.toList());
     }
 
     public String getName() {
-        return name;
+        return this.name;
     }
 
     public String getExceptionName() {
-        return exceptionName;
+        return this.exceptionName;
     }
 
     public boolean isUsed() {
-        return used;
+        return this.used;
     }
 
     public boolean isUnique() {
-        return unique;
+        return this.unique;
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/Email.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/Email.java
@@ -9,14 +9,12 @@ import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Setter
 @EqualsAndHashCode
 @ToString
 public class Email {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/User.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/User.java
@@ -20,7 +20,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
@@ -35,7 +34,6 @@ import wooteco.team.ittabi.legenoaroundhere.domain.post.Post;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Setter
 @ToString(exclude = {"posts", "comments"})
 @SQLDelete(sql = "UPDATE user SET deleted_at = NOW() WHERE id = ?")
 @Where(clause = "deleted_at IS NULL")
@@ -68,7 +66,7 @@ public class User extends BaseEntity implements UserDetails {
     private Area area = null;
 
     @Column(nullable = false, columnDefinition = "tinyint(1) default 0")
-    private boolean authenticatedByEmail;
+    private Boolean authenticatedByEmail;
 
     @Builder
     public User(String email, String nickname, String password, Area area, UserImage image) {
@@ -77,6 +75,7 @@ public class User extends BaseEntity implements UserDetails {
         this.password = new Password(password);
         this.area = area;
         this.image = image;
+        this.authenticatedByEmail = Boolean.FALSE;
     }
 
     private Email makeEmail(String email) {
@@ -106,6 +105,14 @@ public class User extends BaseEntity implements UserDetails {
         if (userImage.hasNotUser()) {
             image.setUser(this);
         }
+    }
+
+    public void setArea(Area area) {
+        this.area = area;
+    }
+
+    public void setAuthenticatedByEmail(Boolean authenticatedByEmail) {
+        this.authenticatedByEmail = authenticatedByEmail;
     }
 
     public boolean isNotSame(User user) {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/User.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/User.java
@@ -85,46 +85,8 @@ public class User extends BaseEntity implements UserDetails {
         return null;
     }
 
-    public void setNickname(String nickname) {
-        this.nickname = new Nickname(nickname);
-    }
-
-    public void setPassword(String password) {
-        this.password = new Password(password);
-    }
-
-    public void setImage(UserImage image) {
-        this.image = image;
-        setUserAtImage(image);
-    }
-
-    private void setUserAtImage(UserImage userImage) {
-        if (Objects.isNull(userImage)) {
-            return;
-        }
-        if (userImage.hasNotUser()) {
-            image.setUser(this);
-        }
-    }
-
-    public void setArea(Area area) {
-        this.area = area;
-    }
-
-    public void setAuthenticatedByEmail(Boolean authenticatedByEmail) {
-        this.authenticatedByEmail = authenticatedByEmail;
-    }
-
-    public boolean isNotSame(User user) {
+    public boolean isNotEquals(User user) {
         return !this.equals(user);
-    }
-
-    public String getPasswordByString() {
-        return this.password.getPassword();
-    }
-
-    public boolean isNotAuthenticatedByEmail() {
-        return !authenticatedByEmail;
     }
 
     @Override
@@ -134,14 +96,8 @@ public class User extends BaseEntity implements UserDetails {
             .collect(Collectors.toList());
     }
 
-    @Override
-    public String getUsername() {
-        return email.getEmail();
-    }
-
-    @Override
-    public String getPassword() {
-        return password.getPassword();
+    public boolean isNotAuthenticatedByEmail() {
+        return !this.authenticatedByEmail;
     }
 
     @Override
@@ -164,11 +120,59 @@ public class User extends BaseEntity implements UserDetails {
         return true;
     }
 
-    public String getEmailByString() {
+    @Override
+    public String getUsername() {
         return this.email.getEmail();
     }
 
-    public String getNicknameByString() {
-        return getNickname().getNickname();
+    public String getNickname() {
+        return this.nickname.getNickname();
+    }
+
+    public void setNickname(String nickname) {
+        this.nickname = new Nickname(nickname);
+    }
+
+    @Override
+    public String getPassword() {
+        return this.password.getPassword();
+    }
+
+    public void setPassword(String password) {
+        this.password = new Password(password);
+    }
+
+    public List<String> getRoles() {
+        return Collections.unmodifiableList(this.roles);
+    }
+
+    public void setImage(UserImage image) {
+        this.image = image;
+        setUserAtImage(image);
+    }
+
+    private void setUserAtImage(UserImage userImage) {
+        if (Objects.isNull(userImage)) {
+            return;
+        }
+        if (userImage.hasNotUser()) {
+            image.setUser(this);
+        }
+    }
+
+    public List<Post> getPosts() {
+        return Collections.unmodifiableList(this.posts);
+    }
+
+    public List<Comment> getComments() {
+        return Collections.unmodifiableList(comments);
+    }
+
+    public void setArea(Area area) {
+        this.area = area;
+    }
+
+    public void setAuthenticatedByEmail(Boolean authenticatedByEmail) {
+        this.authenticatedByEmail = authenticatedByEmail;
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/User.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/User.java
@@ -79,14 +79,6 @@ public class User extends BaseEntity implements UserDetails {
         this.image = image;
     }
 
-    public User(String email, String nickname, Area area, UserImage image) {
-        this.email = makeEmail(email);
-        this.nickname = new Nickname(nickname);
-        this.password = null;
-        this.area = area;
-        this.image = image;
-    }
-
     private Email makeEmail(String email) {
         if (Objects.nonNull(email)) {
             return new Email(email);
@@ -125,7 +117,7 @@ public class User extends BaseEntity implements UserDetails {
     }
 
     public boolean isNotAuthenticatedByEmail() {
-        return authenticatedByEmail == false;
+        return !authenticatedByEmail;
     }
 
     @Override

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/UserImage.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/UserImage.java
@@ -41,7 +41,7 @@ public class UserImage extends BaseEntity {
     }
 
     public boolean hasNotUser() {
-        return Objects.isNull(user);
+        return Objects.isNull(this.user);
     }
 
     public void setUser(User user) {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/mailauth/AuthNumber.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/mailauth/AuthNumber.java
@@ -18,7 +18,7 @@ public class AuthNumber {
     @Column(nullable = false)
     private Integer authNumber;
 
-    public boolean isNotSame(Integer authNumber) {
+    public boolean isDifferent(Integer authNumber) {
         return !this.authNumber.equals(authNumber);
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/mailauth/AuthNumber.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/mailauth/AuthNumber.java
@@ -7,13 +7,11 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @AllArgsConstructor
 @Embeddable
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Setter
 @EqualsAndHashCode
 public class AuthNumber {
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/mailauth/MailAuth.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/mailauth/MailAuth.java
@@ -6,14 +6,12 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import wooteco.team.ittabi.legenoaroundhere.domain.BaseEntity;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.Email;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@Setter
 public class MailAuth extends BaseEntity {
 
     @Embedded

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/mailauth/MailAuth.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/mailauth/MailAuth.java
@@ -27,6 +27,6 @@ public class MailAuth extends BaseEntity {
     }
 
     public boolean isDifferentAuthNumber(int authNumber) {
-        return this.authNumber.isNotSame(authNumber);
+        return this.authNumber.isDifferent(authNumber);
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/util/ImageExtension.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/util/ImageExtension.java
@@ -38,7 +38,7 @@ public enum ImageExtension {
     }
 
     private static boolean noneMatchImageExtension(MultipartFile file) {
-        return Arrays.stream(ImageExtension.values())
+        return Arrays.stream(values())
             .noneMatch(imageExtension -> isSame(file, imageExtension.extension));
     }
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/CommentAssembler.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/CommentAssembler.java
@@ -1,8 +1,11 @@
 package wooteco.team.ittabi.legenoaroundhere.dto;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import wooteco.team.ittabi.legenoaroundhere.domain.comment.Comment;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentAssembler {
 
     public static Comment assemble(User user, CommentRequest commentRequest) {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/CommentResponseAssembler.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/CommentResponseAssembler.java
@@ -2,9 +2,12 @@ package wooteco.team.ittabi.legenoaroundhere.dto;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import wooteco.team.ittabi.legenoaroundhere.domain.comment.Comment;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class CommentResponseAssembler {
 
     public static CommentResponse of(User user, Comment comment) {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PageRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PageRequest.java
@@ -1,14 +1,15 @@
 package wooteco.team.ittabi.legenoaroundhere.dto;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
-@Setter
 @EqualsAndHashCode
 @ToString
 public class PageRequest {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PageableAssembler.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PageableAssembler.java
@@ -1,10 +1,13 @@
 package wooteco.team.ittabi.legenoaroundhere.dto;
 
 import java.util.Objects;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort.Direction;
 import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PageableAssembler {
 
     private static final int MINIMUM_PAGE = 0;

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostAssembler.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostAssembler.java
@@ -1,10 +1,13 @@
 package wooteco.team.ittabi.legenoaroundhere.dto;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import wooteco.team.ittabi.legenoaroundhere.domain.area.Area;
 import wooteco.team.ittabi.legenoaroundhere.domain.post.Post;
 import wooteco.team.ittabi.legenoaroundhere.domain.sector.Sector;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class PostAssembler {
 
     public static Post assemble(PostCreateRequest postCreateRequest, Area area, Sector sector,

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostSearchRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostSearchRequest.java
@@ -1,13 +1,14 @@
 package wooteco.team.ittabi.legenoaroundhere.dto;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import wooteco.team.ittabi.legenoaroundhere.domain.PostSearch;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
-@Setter
 @EqualsAndHashCode
 @ToString
 public class PostSearchRequest {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostUpdateRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PostUpdateRequest.java
@@ -6,14 +6,12 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 import org.springframework.web.multipart.MultipartFile;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
-@Setter
 @EqualsAndHashCode
 @ToString
 public class PostUpdateRequest {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/RankingRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/RankingRequest.java
@@ -1,11 +1,14 @@
 package wooteco.team.ittabi.legenoaroundhere.dto;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
 
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
 @Setter

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/SectorAssembler.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/SectorAssembler.java
@@ -1,9 +1,12 @@
 package wooteco.team.ittabi.legenoaroundhere.dto;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import wooteco.team.ittabi.legenoaroundhere.domain.sector.Sector;
 import wooteco.team.ittabi.legenoaroundhere.domain.sector.SectorState;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SectorAssembler {
 
     public static Sector assemble(User user, SectorRequest sectorRequest, SectorState state) {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserAssembler.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserAssembler.java
@@ -1,10 +1,13 @@
 package wooteco.team.ittabi.legenoaroundhere.dto;
 
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import wooteco.team.ittabi.legenoaroundhere.domain.area.Area;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserAssembler {
 
     private static final PasswordEncoder PASSWORD_ENCODER = new BCryptPasswordEncoder();

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserPasswordUpdateRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserPasswordUpdateRequest.java
@@ -5,13 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
-@Setter
 @EqualsAndHashCode
 @ToString
 public class UserPasswordUpdateRequest {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserResponse.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserResponse.java
@@ -26,7 +26,7 @@ public class UserResponse {
     public static UserResponse from(User user) {
         return UserResponse.builder()
             .id(user.getId())
-            .email(user.getUsername())
+            .email(user.getEmail().getEmail())
             .nickname(user.getNickname())
             .image(UserImageResponse.of(user.getImage()))
             .area(AreaResponse.of(user.getArea()))

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserResponse.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserResponse.java
@@ -26,8 +26,8 @@ public class UserResponse {
     public static UserResponse from(User user) {
         return UserResponse.builder()
             .id(user.getId())
-            .email(user.getEmailByString())
-            .nickname(user.getNicknameByString())
+            .email(user.getUsername())
+            .nickname(user.getNickname())
             .image(UserImageResponse.of(user.getImage()))
             .area(AreaResponse.of(user.getArea()))
             .build();

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserUpdateRequest.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserUpdateRequest.java
@@ -5,13 +5,11 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 import lombok.ToString;
 
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 @Getter
-@Setter
 @EqualsAndHashCode
 @ToString
 public class UserUpdateRequest {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/AreaService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/AreaService.java
@@ -21,6 +21,7 @@ public class AreaService {
     public Page<AreaResponse> searchAllArea(Pageable pageable, String keyword) {
         String likeKeyword = String.format(DB_LIKE_FORMAT, keyword);
         Page<Area> areas = areaRepository.findAllByFullNameIsLike(pageable, likeKeyword);
+
         return areas.map(AreaResponse::of);
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/AreaService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/AreaService.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import wooteco.team.ittabi.legenoaroundhere.domain.area.Area;
 import wooteco.team.ittabi.legenoaroundhere.dto.AreaResponse;
 import wooteco.team.ittabi.legenoaroundhere.repository.AreaRepository;
@@ -16,6 +17,7 @@ public class AreaService {
 
     private final AreaRepository areaRepository;
 
+    @Transactional(readOnly = true)
     public Page<AreaResponse> searchAllArea(Pageable pageable, String keyword) {
         String likeKeyword = String.format(DB_LIKE_FORMAT, keyword);
         Page<Area> areas = areaRepository.findAllByFullNameIsLike(pageable, likeKeyword);

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/CommentService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/CommentService.java
@@ -23,9 +23,9 @@ import wooteco.team.ittabi.legenoaroundhere.exception.NotExistsException;
 import wooteco.team.ittabi.legenoaroundhere.repository.CommentRepository;
 import wooteco.team.ittabi.legenoaroundhere.repository.PostRepository;
 
-@Slf4j
 @Service
 @AllArgsConstructor
+@Slf4j
 public class CommentService {
 
     private final PostRepository postRepository;

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/CommentService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/CommentService.java
@@ -95,7 +95,7 @@ public class CommentService {
     private void validateIsCreator(Comment comment) {
         User user = (User) authenticationFacade.getPrincipal();
 
-        if (user.isNotSame(comment.getCreator())) {
+        if (user.isNotEquals(comment.getCreator())) {
             throw new NotAuthorizedException("권한이 없습니다.");
         }
     }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/MailAuthService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/MailAuthService.java
@@ -84,6 +84,6 @@ public class MailAuthService {
     private void updateUserEmailAuthPassed(Email email) {
         User foundUser = userRepository.findByEmail(email)
             .orElseThrow(() -> new NotExistsException("존재하지 않는 회원입니다."));
-        foundUser.setAuthenticatedByEmail(true);
+        foundUser.setAuthenticatedByEmail(Boolean.TRUE);
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/MailAuthService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/MailAuthService.java
@@ -19,10 +19,9 @@ import wooteco.team.ittabi.legenoaroundhere.repository.MailAuthRepository;
 import wooteco.team.ittabi.legenoaroundhere.repository.UserRepository;
 import wooteco.team.ittabi.legenoaroundhere.utils.MailHandler;
 
-@Slf4j
-@Transactional
 @Service
 @AllArgsConstructor
+@Slf4j
 public class MailAuthService {
 
     private static final int AUTH_NUMBER_MIN = 100_000;

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
@@ -142,7 +142,7 @@ public class PostService {
     private void validateIsCreator(Post post) {
         User user = (User) authenticationFacade.getPrincipal();
 
-        if (user.isNotSame(post.getCreator())) {
+        if (user.isNotEquals(post.getCreator())) {
             throw new NotAuthorizedException("권한이 없습니다.");
         }
     }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/PostService.java
@@ -1,7 +1,6 @@
 package wooteco.team.ittabi.legenoaroundhere.service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -30,10 +29,9 @@ import wooteco.team.ittabi.legenoaroundhere.repository.PostRepository;
 import wooteco.team.ittabi.legenoaroundhere.repository.SectorRepository;
 import wooteco.team.ittabi.legenoaroundhere.utils.ImageUploader;
 
-@Slf4j
-@Transactional
 @Service
 @AllArgsConstructor
+@Slf4j
 public class PostService {
 
     private final PostRepository postRepository;
@@ -116,12 +114,6 @@ public class PostService {
             throw new NotExistsException("해당 Area가 존재하지 않습니다.");
         }
         return subAreas;
-    }
-
-    private List<Area> findSubAreas(List<Area> areas, Area targetArea) {
-        return areas.stream()
-            .filter(area -> area.isSubAreaOf(targetArea))
-            .collect(Collectors.toList());
     }
 
     private List<Sector> findAllSectors(List<Long> sectorIds) {

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/RankingService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/RankingService.java
@@ -26,7 +26,7 @@ public class RankingService {
     private final IAuthenticationFacade authenticationFacade;
     private final PostService postService;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Page<PostWithCommentsCountResponse> searchRanking(Pageable pageable,
         RankingRequest rankingRequest, PostSearchRequest postSearchFilter) {
         Page<Post> allDateZzangPosts = postService

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/SectorService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/SectorService.java
@@ -28,6 +28,7 @@ public class SectorService {
 
     private static final String DB_LIKE_FORMAT = "%%%s%%";
     private static final int DEFAULT_PAGING_NUMBER = 0;
+
     private final SectorRepository sectorRepository;
     private final IAuthenticationFacade authenticationFacade;
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/SectorService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/SectorService.java
@@ -27,7 +27,7 @@ import wooteco.team.ittabi.legenoaroundhere.repository.SectorRepository;
 public class SectorService {
 
     private static final String DB_LIKE_FORMAT = "%%%s%%";
-    protected static final int DEFAULT_PAGING_NUMBER = 0;
+    private static final int DEFAULT_PAGING_NUMBER = 0;
     private final SectorRepository sectorRepository;
     private final IAuthenticationFacade authenticationFacade;
 
@@ -138,6 +138,7 @@ public class SectorService {
             sectorUpdateStateRequest.getReason(), user);
     }
 
+    @Transactional(readOnly = true)
     public List<SectorResponse> findBestSectors(int count) {
         List<Sector> sectors = sectorRepository
             .findAllByStateInAndOrderByPostsCountDesc(PageRequest.of(DEFAULT_PAGING_NUMBER, count),

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/UserService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/UserService.java
@@ -143,6 +143,7 @@ public class UserService implements UserDetailsService {
     }
 
     @Override
+    @Transactional(readOnly = true)
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         return userRepository.findByEmail(new Email(email))
             .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다."));

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/UserService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/UserService.java
@@ -73,7 +73,7 @@ public class UserService implements UserDetailsService {
             .orElseThrow(() -> new NotExistsException("가입되지 않은 회원입니다."));
         checkEmailAuth(user);
         checkPassword(loginRequest, user);
-        String token = jwtTokenGenerator.createToken(user.getEmailByString(), user.getRoles());
+        String token = jwtTokenGenerator.createToken(user.getUsername(), user.getRoles());
         return new TokenResponse(token);
     }
 
@@ -85,7 +85,7 @@ public class UserService implements UserDetailsService {
 
     private void checkPassword(LoginRequest loginRequest, User user) {
         if (!PASSWORD_ENCODER.matches(
-            loginRequest.getPassword(), user.getPasswordByString())) {
+            loginRequest.getPassword(), user.getPassword())) {
             throw new WrongUserInputException("잘못된 비밀번호입니다.");
         }
     }
@@ -118,7 +118,7 @@ public class UserService implements UserDetailsService {
             .orElseThrow(() -> new NotExistsException("사용자를 찾을 수 없습니다."));
 
         String password = userPasswordUpdateRequest.getPassword();
-        if (PASSWORD_ENCODER.matches(password, user.getPasswordByString())) {
+        if (PASSWORD_ENCODER.matches(password, user.getPassword())) {
             throw new WrongUserInputException("기존의 비밀번호와 동일한 비밀번호입니다.");
         }
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/utils/ImageUploader.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/utils/ImageUploader.java
@@ -24,10 +24,9 @@ import wooteco.team.ittabi.legenoaroundhere.exception.NotFoundAlgorithmException
 import wooteco.team.ittabi.legenoaroundhere.exception.NotImageMimeTypeException;
 import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 
-@Slf4j
-@Transactional
 @Component
 @AllArgsConstructor
+@Slf4j
 public class ImageUploader {
 
     public static final String IMAGE_TYPE = "image";
@@ -38,6 +37,7 @@ public class ImageUploader {
     private final S3Uploader s3Uploader;
     private final IAuthenticationFacade authenticationFacade;
 
+    @Transactional
     public List<PostImage> uploadPostImages(List<MultipartFile> multipartFiles) {
         if (Objects.isNull(multipartFiles) || multipartFiles.isEmpty()) {
             return new ArrayList<>();
@@ -47,6 +47,7 @@ public class ImageUploader {
             .collect(Collectors.toList());
     }
 
+    @Transactional
     public PostImage uploadPostImage(MultipartFile multipartFile) {
         if (Objects.isNull(multipartFile)) {
             return null;

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/AcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/AcceptanceTest.java
@@ -16,7 +16,7 @@ import wooteco.team.ittabi.legenoaroundhere.dto.TokenResponse;
 public abstract class AcceptanceTest {
 
     @LocalServerPort
-    public int port;
+    protected int port;
 
     protected static RequestSpecification given() {
         return RestAssured.given().log().all();

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/RankingAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/RankingAcceptanceTest.java
@@ -33,7 +33,6 @@ public class RankingAcceptanceTest extends AcceptanceTest {
 
     private String adminToken;
     private String accessToken;
-
     private String accessTokenA;
     private String accessTokenB;
     private String accessTokenC;

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/UserAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/UserAcceptanceTest.java
@@ -153,16 +153,6 @@ public class UserAcceptanceTest extends AcceptanceTest {
         return createUserBy(params);
     }
 
-    private String createUserWithArea(String email, String nickname, String password) {
-        Map<String, String> params = new HashMap<>();
-        params.put("email", email);
-        params.put("nickname", nickname);
-        params.put("password", password);
-        params.put("areaId", String.valueOf(TEST_AREA_ID));
-
-        return createUserBy(params);
-    }
-
     private String createUserBy(Map<String, String> params) {
         return given()
             .body(params)

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/controller/GlobalExceptionHandlerTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/controller/GlobalExceptionHandlerTest.java
@@ -31,10 +31,10 @@ import wooteco.team.ittabi.legenoaroundhere.service.SectorService;
 @AutoConfigureMockMvc
 class GlobalExceptionHandlerTest {
 
+    private MockMvc mockMvc;
+
     @MockBean
     private SectorService sectorService;
-
-    private MockMvc mockMvc;
 
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext) {

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/controller/PostControllerTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/controller/PostControllerTest.java
@@ -33,10 +33,10 @@ public class PostControllerTest {
     private static final String ANY_ID = "1";
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private MockMvc mockMvc;
 
     @MockBean
     private PostService postService;
-    private MockMvc mockMvc;
 
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext) {

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/controller/UserControllerTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/controller/UserControllerTest.java
@@ -40,10 +40,10 @@ import wooteco.team.ittabi.legenoaroundhere.service.UserService;
 class UserControllerTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private MockMvc mockMvc;
 
     @MockBean
     private UserService userService;
-    private MockMvc mockMvc;
 
     @BeforeEach
     void setUp(WebApplicationContext webApplicationContext) {

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostSearchTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostSearchTest.java
@@ -9,7 +9,7 @@ import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 
 class PostSearchTest {
 
-    protected static final long AREA_ID = 1L;
+    private static final long AREA_ID = 1L;
 
     @DisplayName("생성자에 null 또는 empty가 들어가는 경우 빈 List 필드 생성")
     @Test

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/PostTest.java
@@ -23,27 +23,31 @@ import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 
 public class PostTest {
 
-    private final User user = User.builder()
-        .email(TEST_USER_EMAIL)
-        .nickname(TEST_USER_NICKNAME)
-        .password(TEST_USER_PASSWORD)
-        .build();
+    private static final User USER;
+    private static final Sector SECTOR;
+    private static final Area AREA;
 
-    private final Sector sector = Sector.builder()
-        .name(TEST_SECTOR_NAME)
-        .description(TEST_SECTOR_DESCRIPTION)
-        .creator(user)
-        .lastModifier(user)
-        .state(SectorState.PUBLISHED)
-        .build();
-
-    private final Area area = Area.builder()
-        .fullName(TEST_AREA_FULL_NAME)
-        .firstDepthName(TEST_AREA_FIRST_DEPTH_NAME)
-        .secondDepthName(TEST_AREA_SECOND_DEPTH_NAME)
-        .thirdDepthName(TEST_AREA_THIRD_DEPTH_NAME)
-        .fourthDepthName(TEST_AREA_FOURTH_DEPTH_NAME)
-        .build();
+    static {
+        USER = User.builder()
+            .email(TEST_USER_EMAIL)
+            .nickname(TEST_USER_NICKNAME)
+            .password(TEST_USER_PASSWORD)
+            .build();
+        SECTOR = Sector.builder()
+            .name(TEST_SECTOR_NAME)
+            .description(TEST_SECTOR_DESCRIPTION)
+            .creator(USER)
+            .lastModifier(USER)
+            .state(SectorState.PUBLISHED)
+            .build();
+        AREA = Area.builder()
+            .fullName(TEST_AREA_FULL_NAME)
+            .firstDepthName(TEST_AREA_FIRST_DEPTH_NAME)
+            .secondDepthName(TEST_AREA_SECOND_DEPTH_NAME)
+            .thirdDepthName(TEST_AREA_THIRD_DEPTH_NAME)
+            .fourthDepthName(TEST_AREA_FOURTH_DEPTH_NAME)
+            .build();
+    }
 
     @DisplayName("길이 검증 - 예외 발생")
     @Test
@@ -52,7 +56,7 @@ public class PostTest {
         for (int i = 0; i <= 2000; i++) {
             overLengthInput.append("a");
         }
-        assertThatThrownBy(() -> new Post(overLengthInput.toString(), area, sector, user))
+        assertThatThrownBy(() -> new Post(overLengthInput.toString(), AREA, SECTOR, USER))
             .isInstanceOf(WrongUserInputException.class);
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/area/AreaTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/area/AreaTest.java
@@ -73,39 +73,4 @@ class AreaTest {
     void getLastDepthName_ExistsFourthDepthName_FourthDepthName() {
         assertThat(FOURTH_DEPTH_AREA.getLastDepthName()).isEqualTo(TEST_AREA_FOURTH_DEPTH_NAME);
     }
-
-    @DisplayName("SubArea인지 판단, True - 자기 자신")
-    @Test
-    void isSubAreaOf_MySelf_returnTrue() {
-        assertThat(FIRST_DEPTH_AREA.isSubAreaOf(FIRST_DEPTH_AREA)).isTrue();
-        assertThat(SECOND_DEPTH_AREA.isSubAreaOf(SECOND_DEPTH_AREA)).isTrue();
-        assertThat(THIRD_DEPTH_AREA.isSubAreaOf(THIRD_DEPTH_AREA)).isTrue();
-        assertThat(FOURTH_DEPTH_AREA.isSubAreaOf(FOURTH_DEPTH_AREA)).isTrue();
-    }
-
-    @DisplayName("SubArea인지 판단, False - 하위 지역이 아님")
-    @Test
-    void isSubAreaOf_NotSubArea_returnFalse() {
-        assertThat(FIRST_DEPTH_AREA.isSubAreaOf(SECOND_DEPTH_AREA)).isFalse();
-        assertThat(FIRST_DEPTH_AREA.isSubAreaOf(THIRD_DEPTH_AREA)).isFalse();
-        assertThat(FIRST_DEPTH_AREA.isSubAreaOf(FOURTH_DEPTH_AREA)).isFalse();
-
-        assertThat(SECOND_DEPTH_AREA.isSubAreaOf(THIRD_DEPTH_AREA)).isFalse();
-        assertThat(SECOND_DEPTH_AREA.isSubAreaOf(FOURTH_DEPTH_AREA)).isFalse();
-
-        assertThat(THIRD_DEPTH_AREA.isSubAreaOf(FOURTH_DEPTH_AREA)).isFalse();
-    }
-
-    @DisplayName("SubArea인지 판단, True - 하위 지역")
-    @Test
-    void isSubAreaOf_SubArea_returnTrue() {
-        assertThat(SECOND_DEPTH_AREA.isSubAreaOf(FIRST_DEPTH_AREA)).isTrue();
-
-        assertThat(THIRD_DEPTH_AREA.isSubAreaOf(FIRST_DEPTH_AREA)).isTrue();
-        assertThat(THIRD_DEPTH_AREA.isSubAreaOf(SECOND_DEPTH_AREA)).isTrue();
-
-        assertThat(FOURTH_DEPTH_AREA.isSubAreaOf(FIRST_DEPTH_AREA)).isTrue();
-        assertThat(FOURTH_DEPTH_AREA.isSubAreaOf(SECOND_DEPTH_AREA)).isTrue();
-        assertThat(FOURTH_DEPTH_AREA.isSubAreaOf(THIRD_DEPTH_AREA)).isTrue();
-    }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/infra/JwtTokenDecoderTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/infra/JwtTokenDecoderTest.java
@@ -13,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import wooteco.team.ittabi.legenoaroundhere.service.UserService;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class JwtTokenDecoderTest {
@@ -23,9 +22,6 @@ class JwtTokenDecoderTest {
 
     @Autowired
     private JwtTokenGenerator jwtTokenGenerator;
-
-    @Autowired
-    private UserService userService;
 
     private String token;
 

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/repository/AreaRepositoryTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/repository/AreaRepositoryTest.java
@@ -12,9 +12,9 @@ import wooteco.team.ittabi.legenoaroundhere.domain.area.Area;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 class AreaRepositoryTest {
 
-    protected static final int INIT_DATA_SIZE = 493;
-    protected static final int SEOUL_SUB_AREA_COUNT = INIT_DATA_SIZE - 1;
-    protected static final long SEOUL_AREA_ID = 1L;
+    private static final int INIT_DATA_SIZE = 493;
+    private static final int SEOUL_SUB_AREA_COUNT = INIT_DATA_SIZE - 1;
+    private static final long SEOUL_AREA_ID = 1L;
 
     @Autowired
     AreaRepository areaRepository;

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/ServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/ServiceTest.java
@@ -36,7 +36,7 @@ public abstract class ServiceTest {
     }
 
     protected void setAuthentication(User user) {
-        UserDetails userDetails = userService.loadUserByUsername(user.getEmailByString());
+        UserDetails userDetails = userService.loadUserByUsername(user.getUsername());
         org.springframework.security.core.Authentication authToken = new UsernamePasswordAuthenticationToken(
             user, "TestCredentials", userDetails.getAuthorities());
         authenticationFacade.setAuthentication(authToken);

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
@@ -29,7 +29,7 @@ import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 class UserServiceTest extends ServiceTest {
 
     private static final String TEST_PREFIX = "user_";
-    private static final String NOT_EXIST_PREFIX = "notexist_";
+    private static final String NOT_EXIST_PREFIX = "notExist_";
     private static final int TOKEN_MIN_SIZE = 1;
 
     @Autowired

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
@@ -105,7 +105,7 @@ class UserServiceTest extends ServiceTest {
     void loadUserByUsername_Success() {
         User user = (User) userService.loadUserByUsername(TEST_USER_EMAIL);
 
-        assertThat(user.getEmailByString()).isEqualTo(TEST_USER_EMAIL);
+        assertThat(user.getUsername()).isEqualTo(TEST_USER_EMAIL);
     }
 
     @DisplayName("내 정보 찾기")
@@ -163,7 +163,7 @@ class UserServiceTest extends ServiceTest {
 
         User authUser = (User) authenticationFacade.getAuthentication()
             .getPrincipal();
-        assertThatThrownBy(() -> userService.loadUserByUsername(authUser.getEmailByString()))
+        assertThatThrownBy(() -> userService.loadUserByUsername(authUser.getUsername()))
             .isInstanceOf(UsernameNotFoundException.class);
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
@@ -29,7 +29,7 @@ import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 class UserServiceTest extends ServiceTest {
 
     private static final String TEST_PREFIX = "user_";
-    private static final String NOT_EXIST_PREFIX = "notExist_";
+    private static final String NOT_EXIST_PREFIX = "not_exist_";
     private static final int TOKEN_MIN_SIZE = 1;
 
     @Autowired


### PR DESCRIPTION
**이슈 번호**

resolved: #62 

**작업 내용**

1. 코드 전반 Rombok 적용
2. 미사용 메서드 제거
3. 접근제어자 재설정
4. 2 depth 메서드 분리 - S3Uploader
5. Domain Collection 반환시 unmodified 설정
6. Assembler 생성자 private 설정(static 메서드만 존재)
7. 메서드 순서 정비(사용되는 순서, 마지막에 getter/setter)
8. 도메인 toString LazyLoading 필드 제외
9. 미사용 Setter 제거
10. DB에 담는 값 Wrapping (boolean -> Boolean)
11. Transaction 클래스 -> 메서드로 모두 이동

**테스트 작성 여부**

- [X] Test case

**주의 사항**
