### PR TITLE
refactor: 랭킹 조회시 전체 게시글 비교하게끔 수정

### DIFF
--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/RankingController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/RankingController.java
@@ -25,8 +25,8 @@ public class RankingController {
         PageRequest pageRequest, RankingRequest rankingRequest,
         PostSearchRequest postSearchRequest) {
         Page<PostWithCommentsCountResponse> posts
-            = rankingService.searchRanking(PageableAssembler.assemble(pageRequest), rankingRequest,
-            postSearchRequest);
+            = rankingService.searchRanking(PageableAssembler.assemble(pageRequest, 1000),
+            rankingRequest, postSearchRequest);
 
         return ResponseEntity
             .ok()

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PageableAssembler.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/PageableAssembler.java
@@ -60,4 +60,13 @@ public class PageableAssembler {
             .orElseThrow(() -> new WrongUserInputException(
                 "Direction를 잘못 [" + direction + "] 입력하셨습니다.(asc/desc)"));
     }
+
+    public static Pageable assemble(PageRequest pageRequest, int size) {
+        return org.springframework.data.domain.PageRequest.of(
+            calculatePage(pageRequest.getPage()),
+            size,
+            makeDirection(pageRequest.getDirection()),
+            makeSortedBy(pageRequest.getSortedBy())
+        );
+    }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/RankingService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/RankingService.java
@@ -30,7 +30,7 @@ public class RankingService {
     public Page<PostWithCommentsCountResponse> searchRanking(Pageable pageable,
         RankingRequest rankingRequest, PostSearchRequest postSearchFilter) {
         Page<Post> allDateZzangPosts = postService
-            .getPostByFilter(pageable, postSearchFilter.toPostSearch());
+            .getPostByFilter(Pageable.unpaged(), postSearchFilter.toPostSearch());
         List<Post> filteredDateZzangPosts
             = getPostsThatZzangFilteredByDate(rankingRequest.getCriteria(), allDateZzangPosts);
         Collections.reverse(filteredDateZzangPosts);

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/RankingService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/RankingService.java
@@ -30,7 +30,7 @@ public class RankingService {
     public Page<PostWithCommentsCountResponse> searchRanking(Pageable pageable,
         RankingRequest rankingRequest, PostSearchRequest postSearchFilter) {
         Page<Post> allDateZzangPosts = postService
-            .getPostByFilter(Pageable.unpaged(), postSearchFilter.toPostSearch());
+            .getPostByFilter(pageable, postSearchFilter.toPostSearch());
         List<Post> filteredDateZzangPosts
             = getPostsThatZzangFilteredByDate(rankingRequest.getCriteria(), allDateZzangPosts);
         Collections.reverse(filteredDateZzangPosts);


### PR DESCRIPTION
**이슈 번호**

resolved: #307 

**작업 내용**

1. 랭킹 조회시 1000건 가져오도록 임시 수정, 1000건을 비교하여 랭킹 산정
    - 이전의 경우엔, 가져오는 건끼리의 랭킹 비교가 되어 정확한 랭킹 산출이 안되었었음
    - 추후 #308 에서 페이징 재적용 예정

**테스트 작성 여부**

- [X] Test case

**주의 사항**
