### PR TITLE
feat: 타 유저 정보 조회 기능 구현

### DIFF
--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/UserController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/controller/UserController.java
@@ -9,6 +9,7 @@ import lombok.AllArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -18,6 +19,7 @@ import wooteco.team.ittabi.legenoaroundhere.dto.LoginRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.TokenResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserCreateRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserImageResponse;
+import wooteco.team.ittabi.legenoaroundhere.dto.UserOtherResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserPasswordUpdateRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserUpdateRequest;
@@ -49,6 +51,14 @@ public class UserController {
     @GetMapping(USERS_PATH + ME_PATH)
     public ResponseEntity<UserResponse> findMe() {
         UserResponse user = userService.findMe();
+
+        return ResponseEntity
+            .ok(user);
+    }
+
+    @GetMapping(USERS_PATH_WITH_SLASH + "{userId}")
+    public ResponseEntity<UserOtherResponse> findUser(@PathVariable Long userId) {
+        UserOtherResponse user = userService.findUser(userId);
 
         return ResponseEntity
             .ok(user);

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserOtherResponse.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/UserOtherResponse.java
@@ -1,0 +1,35 @@
+package wooteco.team.ittabi.legenoaroundhere.dto;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@EqualsAndHashCode
+@ToString
+public class UserOtherResponse {
+
+    private Long id;
+    private String email;
+    private String nickname;
+    private UserImageResponse image;
+    private AwardsCountResponse awardsCount;
+
+    public static UserOtherResponse from(User user) {
+        return UserOtherResponse.builder()
+            .id(user.getId())
+            .email(user.getEmail().getEmail())
+            .nickname(user.getNickname())
+            .image(UserImageResponse.of(user.getImage()))
+            .awardsCount(AwardsCountResponse.of(user))
+            .build();
+    }
+}

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/UserService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/UserService.java
@@ -21,6 +21,7 @@ import wooteco.team.ittabi.legenoaroundhere.dto.TokenResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserAssembler;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserCreateRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserImageResponse;
+import wooteco.team.ittabi.legenoaroundhere.dto.UserOtherResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserPasswordUpdateRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserUpdateRequest;
@@ -106,8 +107,12 @@ public class UserService implements UserDetailsService {
     private User findPrincipal() {
         User user = (User) authenticationFacade.getPrincipal();
 
-        return userRepository.findById(user.getId())
-            .orElseThrow(() -> new NotExistsException("사용자를 찾을 수 없습니다."));
+        return findById(user.getId());
+    }
+
+    private User findById(Long userId) {
+        return userRepository.findById(userId)
+            .orElseThrow(() -> new NotExistsException("ID : " + userId + " 에 해당하는 User가 없습니다!"));
     }
 
     @Transactional
@@ -150,5 +155,11 @@ public class UserService implements UserDetailsService {
         UserImage savedUserImage = userImageRepository.save(userImage);
 
         return UserImageResponse.of(savedUserImage);
+    }
+
+    @Transactional(readOnly = true)
+    public UserOtherResponse findUser(Long userId) {
+        User user = findById(userId);
+        return UserOtherResponse.from(user);
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/UserAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/UserAcceptanceTest.java
@@ -14,6 +14,7 @@ import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_NEW_USER_PASSWORD;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_THE_OTHER_EMAIL;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_EMAIL;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_ID;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_NICKNAME;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_OTHER_EMAIL;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_OTHER_PASSWORD;
@@ -33,6 +34,7 @@ import org.springframework.http.MediaType;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.mailauth.MailAuth;
 import wooteco.team.ittabi.legenoaroundhere.dto.TokenResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserImageResponse;
+import wooteco.team.ittabi.legenoaroundhere.dto.UserOtherResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserResponse;
 import wooteco.team.ittabi.legenoaroundhere.repository.MailAuthRepository;
 
@@ -85,7 +87,7 @@ public class UserAcceptanceTest extends AcceptanceTest {
         assertThat(accessToken).hasSizeGreaterThanOrEqualTo(TOKEN_MIN_SIZE);
 
         // 내 정보 조회
-        UserResponse userResponse = findUser(accessToken);
+        UserResponse userResponse = findMe(accessToken);
         assertThat(userResponse).isNotNull();
         assertThat(userResponse.getId()).isNotNull();
         assertThat(userResponse.getEmail()).isEqualTo(TEST_THE_OTHER_EMAIL);
@@ -97,14 +99,14 @@ public class UserAcceptanceTest extends AcceptanceTest {
 
         // 내 정보 수정 - 프로필 사진 포함
         updateMyInfoWithImage(accessToken, "newname", userImageResponse.getId());
-        UserResponse updatedUserResponse = findUser(accessToken);
+        UserResponse updatedUserResponse = findMe(accessToken);
         assertThat(updatedUserResponse.getNickname()).isEqualTo("newname");
         assertThat(updatedUserResponse.getImage()).isNotNull();
         login(TEST_USER_EMAIL, TEST_USER_PASSWORD);
 
         // 내 정보 수정 - 프로필 사진 사용 안함(기본 이미지)
         updateMyInfoWithImage(accessToken, TEST_USER_NICKNAME, null);
-        updatedUserResponse = findUser(accessToken);
+        updatedUserResponse = findMe(accessToken);
         assertThat(updatedUserResponse.getNickname()).isEqualTo(TEST_USER_NICKNAME);
         assertThat(updatedUserResponse.getImage()).isNull();
         login(TEST_USER_EMAIL, TEST_USER_PASSWORD);
@@ -118,7 +120,7 @@ public class UserAcceptanceTest extends AcceptanceTest {
 
         // 회원 탈퇴
         deleteUser(accessToken);
-        findNotExistUser(accessToken);
+        findNotExistMe(accessToken);
     }
 
     /**
@@ -136,23 +138,44 @@ public class UserAcceptanceTest extends AcceptanceTest {
     @DisplayName("회원 지역 관리")
     void joinUserWithArea() {
         TokenResponse tokenResponse = login(TEST_USER_EMAIL, TEST_USER_PASSWORD);
-        UserResponse userResponse = findUser(tokenResponse.getAccessToken());
+        UserResponse userResponse = findMe(tokenResponse.getAccessToken());
         assertThat(userResponse.getArea()).isNull();
 
         tokenResponse = login(TEST_USER_OTHER_EMAIL, TEST_USER_PASSWORD);
         String accessToken = tokenResponse.getAccessToken();
-        userResponse = findUser(accessToken);
+        userResponse = findMe(accessToken);
         assertThat(userResponse.getArea()).isNotNull();
         assertThat(userResponse.getArea().getId()).isEqualTo(TEST_AREA_ID);
 
         updateMyInfoWithoutAreaAndImage(accessToken, TEST_USER_NICKNAME);
-        userResponse = findUser(accessToken);
+        userResponse = findMe(accessToken);
         assertThat(userResponse.getArea()).isNull();
 
         updateMyInfoWithAreaAndWithoutImage(accessToken, TEST_USER_NICKNAME);
-        userResponse = findUser(accessToken);
+        userResponse = findMe(accessToken);
         assertThat(userResponse.getArea()).isNotNull();
         assertThat(userResponse.getArea().getId()).isEqualTo(TEST_AREA_ID);
+    }
+
+    /**
+     * Feature: 타 회원 프로필 조회 Scenario: 타 회원의 프로필을 조회한다.
+     * <p>
+     * Given 타 회원이 가입되어 있다.
+     * <p>
+     * When 타 회원을 조회한다. Then 타 회원이 조회된다.
+     */
+    @DisplayName("타 회원 프로필 조회")
+    @Test
+    void findOtherUser() {
+        TokenResponse tokenResponse = login(TEST_USER_OTHER_EMAIL, TEST_USER_PASSWORD);
+        String accessToken = tokenResponse.getAccessToken();
+
+        UserOtherResponse userOtherResponse = findUser(accessToken, TEST_USER_ID);
+        assertThat(userOtherResponse.getId()).isEqualTo(TEST_USER_ID);
+        assertThat(userOtherResponse.getEmail()).isEqualTo(TEST_USER_EMAIL);
+        assertThat(userOtherResponse.getNickname()).isEqualTo(TEST_USER_NICKNAME);
+        assertThat(userOtherResponse.getAwardsCount()).isNotNull();
+        assertThat(userOtherResponse.getImage());
     }
 
     private String createUserWithoutArea(String email, String nickname, String password) {
@@ -178,7 +201,7 @@ public class UserAcceptanceTest extends AcceptanceTest {
             .header("Location");
     }
 
-    private UserResponse findUser(String accessToken) {
+    private UserResponse findMe(String accessToken) {
         return given()
             .header("X-AUTH-TOKEN", accessToken)
             .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -189,7 +212,7 @@ public class UserAcceptanceTest extends AcceptanceTest {
             .extract().as(UserResponse.class);
     }
 
-    private void findNotExistUser(String accessToken) {
+    private void findNotExistMe(String accessToken) {
         given()
             .header("X-AUTH-TOKEN", accessToken)
             .accept(MediaType.APPLICATION_JSON_VALUE)
@@ -271,5 +294,16 @@ public class UserAcceptanceTest extends AcceptanceTest {
             .delete("/users/me")
             .then()
             .statusCode(HttpStatus.NO_CONTENT.value());
+    }
+
+    private UserOtherResponse findUser(String accessToken, Long userId) {
+        return given()
+            .header("X-AUTH-TOKEN", accessToken)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .get("/users/" + userId)
+            .then()
+            .statusCode(HttpStatus.OK.value())
+            .extract().as(UserOtherResponse.class);
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
@@ -8,6 +8,8 @@ import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AUTH_NUMBER;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_UPDATE_EMAIL;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_EMAIL;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_ID;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_INVALID_ID;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_NICKNAME;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_OTHER_PASSWORD;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_USER_PASSWORD;
@@ -25,6 +27,7 @@ import wooteco.team.ittabi.legenoaroundhere.domain.user.mailauth.MailAuth;
 import wooteco.team.ittabi.legenoaroundhere.dto.LoginRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.TokenResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserCreateRequest;
+import wooteco.team.ittabi.legenoaroundhere.dto.UserOtherResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserPasswordUpdateRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserUpdateRequest;
@@ -179,5 +182,23 @@ class UserServiceTest extends ServiceTest {
             .getPrincipal();
         assertThatThrownBy(() -> userService.loadUserByUsername(authUser.getUsername()))
             .isInstanceOf(UsernameNotFoundException.class);
+    }
+
+    @DisplayName("회원 조회, 성공")
+    @Test
+    void findUser_Success() {
+        UserOtherResponse user = userService.findUser(TEST_USER_ID);
+
+        assertThat(user.getId()).isEqualTo(TEST_USER_ID);
+        assertThat(user.getEmail()).isEqualTo(TEST_USER_EMAIL);
+        assertThat(user.getNickname()).isEqualTo(TEST_USER_NICKNAME);
+        assertThat(user.getAwardsCount()).isNotNull();
+    }
+
+    @DisplayName("회원 조회, 예외 발생 - 유효하지 않은 ID")
+    @Test
+    void findUser_InvalidId_ThrownException() {
+        assertThatThrownBy(() -> userService.findUser(TEST_USER_INVALID_ID))
+            .isInstanceOf(NotExistsException.class);
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/utils/constants/UserConstants.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/utils/constants/UserConstants.java
@@ -2,6 +2,8 @@ package wooteco.team.ittabi.legenoaroundhere.utils.constants;
 
 public class UserConstants {
 
+    public static final Long TEST_USER_INVALID_ID = -1L;
+
     public static final Long TEST_ADMIN_ID = 1L;
     public static final String TEST_ADMIN_EMAIL = "admin@test.com";
     public static final String TEST_ADMIN_NICKNAME = "adminName";


### PR DESCRIPTION
**이슈 번호**

resolved: #330 

**작업 내용**

1. 타 유저 정보 조회 기능 구현

``` json
{
    "id": 2,
    "email": "user@test.com",
    "nickname": "userName",
    "image": null,
    "awardsCount": {
        "topOne": 0,
        "topThree": 0,
        "sector": 0
    }
}
```

**테스트 작성 여부**

- [X] Test case

**주의 사항**
