### PR TITLE
refactor: mysql 필드명 변경(예약어 사용 -> 사용하지 않음)

### DIFF
--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/notification/Notification.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/notification/Notification.java
@@ -57,13 +57,13 @@ public class Notification extends BaseEntity {
 
     @Column(nullable = false, columnDefinition = "tinyint(1) default 0")
     @Builder.Default
-    private Boolean read = Boolean.FALSE;
+    private Boolean isRead = Boolean.FALSE;
 
     public boolean isDifferentReceiver(User user) {
         return !this.receiver.equals(user);
     }
 
     public void read() {
-        this.read = Boolean.TRUE;
+        this.isRead = Boolean.TRUE;
     }
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/NotificationResponseAssembler.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/dto/NotificationResponseAssembler.java
@@ -26,7 +26,7 @@ public class NotificationResponseAssembler {
         return NotificationResponse.builder()
             .id(notification.getId())
             .content(notification.getContent())
-            .isRead(notification.getRead())
+            .isRead(notification.getIsRead())
             .location(makeLocation(notification))
             .build();
     }

--- a/back-end/legeno-around-here/src/main/resources/db/migration/V8__Issue_245_Create_Notification.sql
+++ b/back-end/legeno-around-here/src/main/resources/db/migration/V8__Issue_245_Create_Notification.sql
@@ -7,7 +7,7 @@ CREATE TABLE `notification`
     `post_id`     BIGINT(20),
     `user_id`     BIGINT(20),
     `receiver_id` BIGINT(20),
-    `read`        TINYINT(1)   NOT NULL,
+    `is_read`     TINYINT(1)   NOT NULL,
     `created_at`  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `modified_at` DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     `deleted_at`  DATETIME              DEFAULT NULL,

--- a/back-end/legeno-around-here/src/main/resources/init-mock-data.sql
+++ b/back-end/legeno-around-here/src/main/resources/init-mock-data.sql
@@ -83,7 +83,7 @@ VALUES (1, '탕수육 사진1',
         now(), now());
 
 INSERT INTO notification
-(id, created_at, deleted_at, modified_at, comment_id, content, post_id, read, receiver_id,
+(id, created_at, deleted_at, modified_at, comment_id, content, post_id, is_read, receiver_id,
  sector_id, user_id)
 VALUES (1, now(), null, now(), null, '이것은 안읽은 글 짱 알림.', 1, false, 3, null, null),
        (2, now() - 1, null, now(), null, '이것은 읽은 글 짱 알림', 1, false, 3, null, null),

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/CommentServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/CommentServiceTest.java
@@ -137,7 +137,7 @@ public class CommentServiceTest extends ServiceTest {
         assertThat(notification.getComment()).isNull();
         assertThat(notification.getUser()).isNull();
         assertThat(notification.getSector()).isNull();
-        assertThat(notification.getRead()).isFalse();
+        assertThat(notification.getIsRead()).isFalse();
     }
 
     @DisplayName("댓글 생성시 기존 알림이 있을 경우, 글 작성자에게 새 알림 & 기존 알림 삭제")
@@ -168,7 +168,7 @@ public class CommentServiceTest extends ServiceTest {
         assertThat(notification.getComment()).isNull();
         assertThat(notification.getUser()).isNull();
         assertThat(notification.getSector()).isNull();
-        assertThat(notification.getRead()).isFalse();
+        assertThat(notification.getIsRead()).isFalse();
     }
 
     @DisplayName("대댓글 작성, 성공")
@@ -240,7 +240,7 @@ public class CommentServiceTest extends ServiceTest {
         assertThat(notification.getComment()).isEqualTo(comment);
         assertThat(notification.getUser()).isNull();
         assertThat(notification.getSector()).isNull();
-        assertThat(notification.getRead()).isFalse();
+        assertThat(notification.getIsRead()).isFalse();
     }
 
     @DisplayName("대댓글 생성시 기존 알림이 있을 경우, 댓글 작성자에게 새 알림 & 기존 알림 삭제")
@@ -272,7 +272,7 @@ public class CommentServiceTest extends ServiceTest {
         assertThat(notification.getComment()).isEqualTo(comment);
         assertThat(notification.getUser()).isNull();
         assertThat(notification.getSector()).isNull();
-        assertThat(notification.getRead()).isFalse();
+        assertThat(notification.getIsRead()).isFalse();
     }
 
     @DisplayName("댓글 조회 - 성공")
@@ -491,7 +491,7 @@ public class CommentServiceTest extends ServiceTest {
         assertThat(notification.getComment()).isEqualTo(comment);
         assertThat(notification.getUser()).isNull();
         assertThat(notification.getSector()).isNull();
-        assertThat(notification.getRead()).isFalse();
+        assertThat(notification.getIsRead()).isFalse();
     }
 
     @DisplayName("짱 비활성화시 작성자에게 알림 발송하지 않음")
@@ -551,7 +551,7 @@ public class CommentServiceTest extends ServiceTest {
         assertThat(notification.getComment()).isEqualTo(comment);
         assertThat(notification.getUser()).isNull();
         assertThat(notification.getSector()).isNull();
-        assertThat(notification.getRead()).isFalse();
+        assertThat(notification.getIsRead()).isFalse();
     }
 
     @DisplayName("코멘트 내용 변경, 성공")

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/PostServiceTest.java
@@ -421,7 +421,7 @@ public class PostServiceTest extends ServiceTest {
         assertThat(notification.getComment()).isNull();
         assertThat(notification.getUser()).isNull();
         assertThat(notification.getSector()).isNull();
-        assertThat(notification.getRead()).isFalse();
+        assertThat(notification.getIsRead()).isFalse();
     }
 
     @DisplayName("짱 비활성화시 작성자에게 알림 발송하지 않음")
@@ -482,7 +482,7 @@ public class PostServiceTest extends ServiceTest {
         assertThat(notification.getComment()).isNull();
         assertThat(notification.getUser()).isNull();
         assertThat(notification.getSector()).isNull();
-        assertThat(notification.getRead()).isFalse();
+        assertThat(notification.getIsRead()).isFalse();
     }
 
     @DisplayName("내가 쓴 글 검색 - 성공")

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
@@ -129,7 +129,7 @@ class UserServiceTest extends ServiceTest {
         Notification notification = notifications.get(0);
         assertThat(notification.getId()).isNotNull();
         assertThat(notification.getContent()).contains(TEST_USER_NICKNAME);
-        assertThat(notification.getRead()).isFalse();
+        assertThat(notification.getIsRead()).isFalse();
         assertThat(notification.getComment()).isNull();
         assertThat(notification.getPost()).isNull();
         assertThat(notification.getSector()).isNull();

--- a/back-end/legeno-around-here/src/test/resources/data.sql
+++ b/back-end/legeno-around-here/src/test/resources/data.sql
@@ -57,7 +57,7 @@ VALUES (1, 'admin@test.com', 111111, now(), now()),
        (10, 'notices2@capzzang.co.kr', 111111, now(), now());
 
 INSERT INTO notification
-(id, created_at, deleted_at, modified_at, comment_id, content, post_id, read, receiver_id,
+(id, created_at, deleted_at, modified_at, comment_id, content, post_id, is_read, receiver_id,
  sector_id, user_id)
 VALUES (1, now(), null, now(), null, 'userName님, 가입을 진심으로 축하드립니다.', null, false, 9, null, null),
        (2, now() - 1, null, now(), null, 'userName님, 가입을 진심으로 축하드립니다.', null, false, 9, null, null),


### PR DESCRIPTION
**이슈 번호**

resolved: #348 

**작업 내용**

1. 알림의 필드가 mysql의 예약어라 버그 발생

**테스트 작성 여부**

- [X] Test case

**주의 사항**
