### PR TITLE
fix: 랭킹 프론트 좀 더 넓은 에러 핸들링 코드 추가 [ISSUE-355]

### DIFF
--- a/front-end/legeno-around-here/src/components/pages/ranking/RankingPage.js
+++ b/front-end/legeno-around-here/src/components/pages/ranking/RankingPage.js
@@ -47,22 +47,25 @@ const RankingPage = () => {
 
   /* 처음에 보여줄 글 목록을 가져옴 */
   useEffect(() => {
-    findRankedPostsFromPage(mainAreaId, criteria, 0, accessToken).then(
-      (firstPosts) => {
-        if (firstPosts.length === 0) {
+    findRankedPostsFromPage(mainAreaId, criteria, 0, accessToken)
+      .then((firstPosts) => {
+        if (!firstPosts || firstPosts.length === 0) {
           setHasMore(false);
           return;
         }
         setPosts(firstPosts);
-      },
-    );
+      })
+      .catch((e) => {
+        console.log(e);
+        setHasMore(false);
+      });
     setPage(1);
   }, [mainAreaId, accessToken, criteria]);
 
   const fetchNextPosts = () => {
     findRankedPostsFromPage(mainAreaId, criteria, page, accessToken)
       .then((nextPosts) => {
-        if (nextPosts.length === 0) {
+        if (!nextPosts || nextPosts.length === 0) {
           setHasMore(false);
           return;
         }


### PR DESCRIPTION
**이슈 번호**

resolved: #355 

**작업 내용**

1. 랭킹 프론트 좀 더 넓은 에러 핸들링 코드 추가

**테스트 작성 여부**

- [ ] Test case

**주의 사항**
로컬에선 애초에 이 문제때문에 랭킹페이지가 아얘 안보이지는 않았었음.
따라서 실서버에 올렸는데도 문제가 해결되지 않을 수 있음.