### PR TITLE
feat: 부문 상세 화면 구현 [ISSUE-358]

### DIFF
--- a/front-end/legeno-around-here/src/App.js
+++ b/front-end/legeno-around-here/src/App.js
@@ -16,6 +16,7 @@ import Notification from './components/pages/home/Notification';
 import InitPage from './components/pages/InitPage';
 import OtherPosts from './components/pages/OthersProfile/OtherPosts';
 import ErrorPage from './components/pages/ErrorPage';
+import SectorDetailPage from './components/pages/sector/SectorDetailPage'
 
 function App() {
   const mainArea = localStorage.getItem('mainAreaName');
@@ -36,6 +37,7 @@ function App() {
         <Route path='/posting' exact component={PostingPage} />
         <Route path='/posts/:postId/update' exact component={PostingUpdatePage} />
         <Route path='/sector' exact component={SectorPage} />
+        <Route path='/sectors/:sectorId' exact component={SectorDetailPage} />
         <Route path='/posts/:postId' exact component={PostDetailPage} />
         <Route path='/home' exact component={HomePage} />
         <Route path='/ranking' exact component={RankingPage} />

--- a/front-end/legeno-around-here/src/components/api/API.js
+++ b/front-end/legeno-around-here/src/components/api/API.js
@@ -527,12 +527,6 @@ export const findOthersProfileById = async ({ accessToken, userId }) => {
     });
 };
 
-const redirectLoginWhenUnauthorized = (error) => {
-  if (error.response && error.response.status === 403) {
-    document.location.href = '/login';
-  }
-};
-
 export const getMyNotification = (accessToken, setNotifications) => {
   const config = {
     headers: {
@@ -585,4 +579,31 @@ export const readNotification = (accessToken, id) => {
       alert('알림을 읽음 처리하지 못했습니다.');
       console.log(error);
     });
+};
+
+export const findSector = async (accessToken, sectorId) => {
+  const config = {
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'X-Auth-Token': accessToken,
+    },
+  };
+  return await axios
+    .get(DEFAULT_URL + '/sectors/' + sectorId, config)
+    .then((response) => {
+      if (response.status === HTTP_STATUS_OK) {
+        return response.data;
+      }
+    })
+    .catch((error) => {
+      redirectLoginWhenUnauthorized(error);
+      alert(`부문 상세정보를 가져올 수 없습니다.${error}`);
+      document.location.href = '/home';
+    });
+};
+
+const redirectLoginWhenUnauthorized = (error) => {
+  if (error.response && error.response.status === 403) {
+    document.location.href = '/login';
+  }
 };

--- a/front-end/legeno-around-here/src/components/myProfile/LinksSection.js
+++ b/front-end/legeno-around-here/src/components/myProfile/LinksSection.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
+import LinkWithoutStyle from '../../util/LinkWithoutStyle'
 
 export const NavSection = styled.div`
   width: 97%;
@@ -29,21 +29,12 @@ export const NavElement = ({ linkTo, children }) => {
   );
 };
 
-const StyledLink = styled(Link)`
+const StyledLink = styled(LinkWithoutStyle)`
   height: 70px;
   display: flex;
   flex-direction: column;
   justify-content: center;
   margin-bottom: 5px;
   text-align: left;
-  text-decoration: none;
   background-color: #ffffff;
-
-  &:focus,
-  &:hover,
-  &:visited,
-  &:link,
-  &:active {
-    text-decoration: none;
-  }
 `;

--- a/front-end/legeno-around-here/src/components/myProfile/PrivacySection.js
+++ b/front-end/legeno-around-here/src/components/myProfile/PrivacySection.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
-import { Link } from 'react-router-dom';
 
 import { MAIN_COLOR } from '../../constants/Color';
+import LinkWithoutStyle from '../../util/LinkWithoutStyle'
 
 export const ProfilePhoto = styled.div`
   width: 100px;
@@ -39,13 +39,13 @@ export const PrivacyBox = styled.div`
   text-align: left;
 `;
 
-export const PrivacyEditBox = styled(Link)`
+export const PrivacyEditBox = styled(LinkWithoutStyle)`
   margin: 0px auto;
   font-size: 15px;
   display: block;
 `;
 
-export const PrivacySignOutBox = styled(Link)`
+export const PrivacySignOutBox = styled(LinkWithoutStyle)`
   margin: 0px auto;
   font-size: 15px;
   display: block;

--- a/front-end/legeno-around-here/src/components/myProfile/PrivacySection.js
+++ b/front-end/legeno-around-here/src/components/myProfile/PrivacySection.js
@@ -45,7 +45,7 @@ export const PrivacyEditBox = styled(LinkWithoutStyle)`
   display: block;
 `;
 
-export const PrivacySignOutBox = styled(LinkWithoutStyle)`
+export const PrivacySignOutBox = styled.div`
   margin: 0px auto;
   font-size: 15px;
   display: block;

--- a/front-end/legeno-around-here/src/components/pages/JoinPage.js
+++ b/front-end/legeno-around-here/src/components/pages/JoinPage.js
@@ -1,6 +1,4 @@
 import React, { useCallback, useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
-
 import Avatar from '@material-ui/core/Avatar';
 import Button from '@material-ui/core/Button';
 import CssBaseline from '@material-ui/core/CssBaseline';
@@ -12,6 +10,7 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import { createUser, checkJoined, sendAuthMail, checkAuthNumber } from '../api/API';
+import LinkWithoutStyle from '../../util/LinkWithoutStyle'
 
 const mailInputStyle = {
   width: '70%',
@@ -295,9 +294,9 @@ function JoinForm() {
           </Button>
           <Grid container justify='flex-end'>
             <Grid item>
-              <Link to='/login' variant='body2'>
+              <LinkWithoutStyle to='/login' variant='body2'>
                 이미 계정이 있으신가요? 로그인을 해주세요!
-              </Link>
+              </LinkWithoutStyle>
             </Grid>
           </Grid>
         </form>

--- a/front-end/legeno-around-here/src/components/pages/LoginPage.js
+++ b/front-end/legeno-around-here/src/components/pages/LoginPage.js
@@ -1,5 +1,4 @@
 import React, { useCallback, useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
 import { loginUser } from '../api/API';
 
 import Avatar from '@material-ui/core/Avatar';
@@ -13,6 +12,7 @@ import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
 import { removeAccessTokenCookie } from '../../util/TokenUtils';
+import LinkWithoutStyle from '../../util/LinkWithoutStyle'
 
 const Copyright = () => {
   return (
@@ -119,9 +119,9 @@ function LoginForm() {
           </Button>
           <Grid container>
             <Grid item>
-              <Link to='/join' variant='body2'>
+              <LinkWithoutStyle to='/join' variant='body2'>
                 {'처음이신가요? 회원가입을 해주세요!'}
-              </Link>
+              </LinkWithoutStyle>
             </Grid>
           </Grid>
         </form>

--- a/front-end/legeno-around-here/src/components/pages/home/HomeTopBar.js
+++ b/front-end/legeno-around-here/src/components/pages/home/HomeTopBar.js
@@ -10,7 +10,7 @@ import Autocomplete from '@material-ui/lab/Autocomplete';
 import { getAccessTokenFromCookie } from '../../../util/TokenUtils';
 import { findAllSimpleSectors, getUnreadNotificationCount } from '../../api/API';
 import AreaSearch from '../../AreaSearch';
-import { Link } from 'react-router-dom';
+import LinkWithoutStyle from '../../../util/LinkWithoutStyle'
 
 const useStyles = makeStyles(() => ({
   grow: {
@@ -71,13 +71,13 @@ const HomeTopBar = ({ setter, sectorId }) => {
           />
           <div className={classes.grow} />
           <div className={classes.sectionDesktop}>
-            <Link to='/notification'>
+            <LinkWithoutStyle to='/notification'>
               <IconButton aria-label='show 17 new notifications' color='inherit'>
                 <Badge badgeContent={unreadNotification} color='secondary'>
                   <NotificationsIcon style={{ color: 'white' }} />
                 </Badge>
               </IconButton>
-            </Link>
+            </LinkWithoutStyle>
           </div>
         </Toolbar>
       </AppBar>

--- a/front-end/legeno-around-here/src/components/pages/post/PostDetail.js
+++ b/front-end/legeno-around-here/src/components/pages/post/PostDetail.js
@@ -11,8 +11,8 @@ import Comments from './Comments';
 import PostImages from './PostImages';
 import { convertDateFormat } from '../../../util/TimeUtils';
 import UpdatePostButton from './UpdatePostButton';
-import { Link } from 'react-router-dom';
 import PostReportSection from './PostReportSection';
+import LinkWithoutStyle from '../../../util/LinkWithoutStyle'
 
 const PostDetail = ({ post, myInfo }) => {
   const accessToken = getAccessTokenFromCookie();
@@ -67,7 +67,7 @@ const PostDetail = ({ post, myInfo }) => {
           <Typography>{post.area.fullName}</Typography>
         </Grid>
         <Grid container item xs={6} alignItems='flex-start' justify='flex-end' direction='row'>
-          <Typography component={Link} to={isMyPost ? '/users/me' : '/users/' + post.creator.id}>
+          <Typography component={LinkWithoutStyle} to={isMyPost ? '/users/me' : '/users/' + post.creator.id}>
             {post.creator.nickname}
           </Typography>
         </Grid>

--- a/front-end/legeno-around-here/src/components/pages/post/UpdatePostButton.js
+++ b/front-end/legeno-around-here/src/components/pages/post/UpdatePostButton.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import Button from '@material-ui/core/Button';
-import { Link } from 'react-router-dom';
+import LinkWithoutStyle from '../../../util/LinkWithoutStyle'
 
 const UpdatePostButton = ({ post }) => {
   return (
     <Button>
-      <Link to={`/posts/${post.id}/update`}>글 수정</Link>
+      <LinkWithoutStyle to={`/posts/${post.id}/update`}>글 수정</LinkWithoutStyle>
     </Button>
   );
 };

--- a/front-end/legeno-around-here/src/components/pages/sector/SectorDetailPage.js
+++ b/front-end/legeno-around-here/src/components/pages/sector/SectorDetailPage.js
@@ -1,0 +1,150 @@
+import makeStyles from '@material-ui/core/styles/makeStyles'
+import { MAIN_COLOR } from '../../../constants/Color'
+import { getAccessTokenFromCookie } from '../../../util/TokenUtils'
+import React, { useEffect, useState } from 'react'
+import { findMyInfo, findSector } from '../../api/API'
+import Loading from '../../Loading'
+import PostDetailTopBar from '../post/PostDetailTopBar'
+import Container from '@material-ui/core/Container'
+import Typography from '@material-ui/core/Typography'
+import LinkWithoutStyle from '../../../util/LinkWithoutStyle'
+import BottomBlank from '../../BottomBlank'
+import Button from '@material-ui/core/Button'
+import Bottom from '../../Bottom'
+import { DEFAULT_IMAGE_URL } from '../myProfileEdit/MyProfileEditPage'
+
+const useStyle = makeStyles({
+  sectorNameSection: {
+    margin: '25px auto',
+    textAlign: 'center',
+  },
+  sectorDescriptionSection: {
+    margin: '25px auto',
+    textAlign: 'center',
+  },
+  sectorCreatorSection: {
+    width: '90%',
+    display: 'flex',
+    alignItems: 'center',
+    margin: '20px auto',
+  },
+  sectorCreatorSectionBackground: {
+    borderRadius: '20px',
+    border: '1px solid rgba(20, 80, 200, 0.5)',
+    padding: '5px 15px 15px 15px',
+  },
+  creatorProfilePhoto: (props) => ({
+    width: '70px',
+    height: '70px',
+    backgroundRepeat: 'no-repeat',
+    backgroundSize: 'cover',
+    backgroundPosition: 'center',
+    borderRadius: '300px',
+    backgroundImage: `url(${props.photoUrl})`,
+    border: `1px solid ${MAIN_COLOR}`,
+  }),
+  nickname: {
+    display: 'inline',
+    fontSize: '25px',
+  },
+  creatorInfo: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'center',
+    marginLeft: '20px',
+    textAlign: 'left',
+    color: 'black',
+  },
+  buttonSection: {
+    width: '99%',
+    margin: '30px auto',
+    textAlign: 'center',
+  },
+  goToPostsButton: {
+    width: '90%',
+    margin: 'auto',
+    borderRadius: '12px',
+  },
+});
+
+const SectorDetailPage = ({ match }) => {
+  const sectorId = match.params.sectorId;
+  const accessToken = getAccessTokenFromCookie();
+  const [sector, secSector] = useState({
+    name: '',
+    description: '',
+    creator: {
+      id: null,
+      nickname: '',
+    },
+  });
+  const [loading, setLoading] = useState(false);
+  const [myInfo, setMyInfo] = useState({
+    id: null,
+  });
+
+  const classes = useStyle({
+    photoUrl: sector.creator.image ? sector.creator.image : DEFAULT_IMAGE_URL,
+  });
+
+  const isSectorCreatorMe = () => sector.creator.id === myInfo.id;
+
+  useEffect(() => {
+    const loadMyInfo = async () => {
+      setLoading(true);
+      const foundMyInfo = await findMyInfo(accessToken);
+      setMyInfo(foundMyInfo);
+      setLoading(false);
+    };
+
+    const loadSector = async () => {
+      setLoading(true);
+      const sector = await findSector(accessToken, sectorId);
+      console.log(sector);
+      secSector(sector);
+      setLoading(false);
+    };
+    loadMyInfo();
+    loadSector();
+  }, [accessToken, sectorId]);
+
+  if (loading) {
+    return <Loading />;
+  }
+  return (
+    <>
+      <PostDetailTopBar />
+      <Container>
+        <div className={classes.sectorNameSection}>
+          <Typography variant='h4'>{sector.name} 부문</Typography>
+        </div>
+        <div className={classes.sectorDescriptionSection}>
+          <Typography variant='h6'>{sector.description}</Typography>
+        </div>
+        <div className={classes.sectorCreatorSectionBackground}>
+          <Typography>부문 창시자</Typography>
+          <LinkWithoutStyle
+            to={isSectorCreatorMe() ? '/users/me' : '/users/' + sector.creator.id}
+            className={classes.sectorCreatorSection}
+          >
+            <div className={classes.creatorProfilePhoto} />
+            <div className={classes.creatorInfo}>
+              <Typography component='h1' variant='h5'>
+                <div className={classes.nickname}>{sector.creator.nickname}</div>
+              </Typography>
+            </div>
+          </LinkWithoutStyle>
+        </div>
+        <div className={classes.buttonSection}>
+          <Button variant="contained" color="primary" className={classes.goToPostsButton} size='large'>
+            자랑글 보러 가기
+          </Button>
+        </div>
+        <BottomBlank />
+      </Container>
+      <Bottom />
+    </>
+  );
+};
+
+export default SectorDetailPage;

--- a/front-end/legeno-around-here/src/components/pages/sector/SectorItem.js
+++ b/front-end/legeno-around-here/src/components/pages/sector/SectorItem.js
@@ -3,23 +3,26 @@ import ListItem from '@material-ui/core/ListItem';
 import Divider from '@material-ui/core/Divider';
 import ListItemText from '@material-ui/core/ListItemText';
 import Typography from '@material-ui/core/Typography';
+import LinkWithoutStyle from '../../../util/LinkWithoutStyle'
 
 const SectorItem = ({ sector }) => {
   return (
     <>
-      <ListItem alignItems="flex-start">
-        <ListItemText
-          primary={sector.name + ' 부문'}
-          secondary={sector.description}
-        />
-        <div>
-          <Typography variant="subtitle1">
-            {sector.creator.nickname} 만듦
-          </Typography>
-          <Typography variant="subtitle1"> 명 도전 중</Typography>
-        </div>
-      </ListItem>
-      <Divider />
+      <LinkWithoutStyle to={'/sectors/' + sector.id}>
+        <ListItem alignItems="flex-start">
+          <ListItemText
+            primary={sector.name + ' 부문'}
+            secondary={sector.description}
+          />
+          <div>
+            <Typography variant="subtitle1">
+              {sector.creator.nickname} 만듦
+            </Typography>
+            <Typography variant="subtitle1"> 명 도전 중</Typography>
+          </div>
+        </ListItem>
+        <Divider />
+      </LinkWithoutStyle>
     </>
   );
 };

--- a/front-end/legeno-around-here/src/util/LinkWithoutStyle.js
+++ b/front-end/legeno-around-here/src/util/LinkWithoutStyle.js
@@ -1,0 +1,17 @@
+import styled from 'styled-components'
+import { Link } from 'react-router-dom'
+
+const LinkWithoutStyle = styled(Link)`
+  color: black;
+  text-decoration: none;
+  
+  &:focus,
+  &:hover,
+  &:visited,
+  &:link,
+  &:active {
+    text-decoration: none;
+  }
+`;
+
+export default LinkWithoutStyle;


### PR DESCRIPTION
**이슈 번호**

resolved: #358 

**작업 내용**

1. 부문 상세 화면 구현
 - 부문 창시자정보 클릭시 타인 프로필 페이지로 연결됨
 - 자랑글 보러가기 버튼은 동작하지 않음
![image](https://user-images.githubusercontent.com/28949340/91478498-f2aa8f00-e8da-11ea-8932-fe336164d1fa.png)
**테스트 작성 여부**

- [ ] Test case

**주의 사항**
