### PR TITLE
feat: ellipsis 적용 및 홈 화면 글 내용 수정 [ISSUE-424]

### DIFF
--- a/front-end/legeno-around-here/package.json
+++ b/front-end/legeno-around-here/package.json
@@ -15,6 +15,7 @@
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-infinite-scroll-component": "^5.0.5",
+    "react-lines-ellipsis": "^0.14.1",
     "react-loading": "^2.0.3",
     "react-router-dom": "^5.2.0",
     "react-scripts": "3.4.1",

--- a/front-end/legeno-around-here/src/components/Loading.js
+++ b/front-end/legeno-around-here/src/components/Loading.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import styled from 'styled-components';
-import {makeStyles} from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 
 import ReactLoading from 'react-loading';
+import Typography from '@material-ui/core/Typography';
 
 const CenterAlign = styled.div`
   width: 98%;
@@ -28,10 +29,12 @@ const Loading = () => {
 
   return (
     <CenterAlign>
-      <TextForWait>잠시만 기다려주세요...</TextForWait>
+      <TextForWait>
+        <Typography>잠시만 기다려주세요...</Typography>
+      </TextForWait>
       <ReactLoading
         type={'bars'}
-        color="#0123B4"
+        color='#0123B4'
         height={'20%'}
         width={'20%'}
         delay={500}

--- a/front-end/legeno-around-here/src/components/PostItem.js
+++ b/front-end/legeno-around-here/src/components/PostItem.js
@@ -1,93 +1,103 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import Card from '@material-ui/core/Card';
-import CardMedia from '@material-ui/core/CardMedia';
-import CardContent from '@material-ui/core/CardContent';
-import CardActions from '@material-ui/core/CardActions';
 import IconButton from '@material-ui/core/IconButton';
 import Typography from '@material-ui/core/Typography';
 import FavoriteBorderIcon from '@material-ui/icons/FavoriteBorder';
 import FavoriteIcon from '@material-ui/icons/Favorite';
 import CommentIcon from '@material-ui/icons/Comment';
 import { convertDateFormat } from '../util/TimeUtils';
+import Grid from '@material-ui/core/Grid';
+import LinesEllipsis from 'react-lines-ellipsis';
 
 const useStyles = makeStyles(() => ({
-  grow: {
-    flexGrow: 1,
-  },
   root: {
-    display: 'flex',
-  },
-  details: {
-    display: 'flex',
-    flexDirection: 'column',
-  },
-  content: {
-    flex: '1 0 auto',
+    borderBottom: '1px solid black',
+    marginTop: '5px',
   },
   cover: {
-    flex: '1 0 auto',
+    position: 'relative',
     opacity: 0.7,
     backgroundSize: 'contain',
   },
   photoText: {
-    textAlign: 'center',
-    marginTop: 100,
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    color: 'black',
+    fontSize: '2rem',
+  },
+  img: {
+    margin: 'auto',
+    display: 'block',
+    maxWidth: '100%',
+    maxHeight: '100%',
   },
 }));
 
 const PostItem = ({ post }) => {
   const classes = useStyles();
+  const [isLoaded, setIsLoaded] = useState(false);
 
   const { area, commentsCount, createdAt, creator, images, id, zzang, sector, writing } = post;
 
   return (
-    <Card className={classes.root} data-id={id} onClick={() => (document.location.href = `/posts/${id}`)}>
-      <div className={classes.details}>
-        <CardContent className={classes.content}>
-          <Typography component='h6' variant='h5'>
-            {sector.name} 부문
+    <Grid
+      container
+      direction='row'
+      justify='flex-start'
+      alignItems='center'
+      spacing={2}
+      onClick={() => (document.location.href = `/posts/${id}`)}
+      className={classes.root}
+    >
+      <Grid item xs>
+        <Grid item xs>
+          <Typography variant='h6'>{sector.name} 부문</Typography>
+          <Typography variant='subtitle1'>
+            <LinesEllipsis text={writing} maxLine='3' ellipsis='...' trimRight basedOn='letters' />
           </Typography>
-          <Typography variant='subtitle1' color='textSecondary'>
-            {convertDateFormat(createdAt)}
-          </Typography>
-
-          <Typography
-            variant='body2'
-            color='textSecondary'
-            component='p'
-            style={{
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              width: '190px',
-            }}
-          >
-            {writing}
-          </Typography>
-          <Typography variant='subtitle1' color='textSecondary'>
-            작성자 : {creator.nickname}
-          </Typography>
-          <Typography variant='body2' color='textSecondary' component='p'>
-            작성 지역 : {area.fullName}
-          </Typography>
-        </CardContent>
-        <CardActions disableSpacing>
-          <IconButton>
-            {zzang.activated === true ? <FavoriteIcon /> : <FavoriteBorderIcon />}
-            {zzang.count}
-          </IconButton>
-          <IconButton>
-            <CommentIcon />
-            {commentsCount}
-          </IconButton>
-        </CardActions>
-      </div>
+        </Grid>
+        <Grid container direction='column' justify='space-between'>
+          <Grid item xs>
+            <Typography variant='body2' color='textSecondary'>
+              {convertDateFormat(createdAt)}
+            </Typography>
+          </Grid>
+          <Grid item xs>
+            <Typography variant='body2' color='textSecondary' component='p'>
+              <span>'{area.fullName}'에서</span>
+            </Typography>
+          </Grid>
+          <Grid item xs>
+            <Typography variant='body2' color='textSecondary'>
+              <span>'{creator.nickname}'님이 작성하셨습니다.</span>
+            </Typography>
+          </Grid>
+          <Grid item xs>
+            <IconButton size='small'>
+              {zzang.activated === true ? <FavoriteIcon /> : <FavoriteBorderIcon />}
+              {zzang.count}
+            </IconButton>
+            <IconButton size='small'>
+              <CommentIcon />
+              {commentsCount}
+            </IconButton>
+          </Grid>
+        </Grid>
+      </Grid>
       {images.length > 0 && (
-        <CardMedia className={classes.cover} image={images[0].url} title='Live from space album cover'>
-          {images.length > 1 && <div className={classes.photoText}>+{images.length - 1}</div>}
-        </CardMedia>
+        <Grid item xs className={classes.cover}>
+          <img
+            className={classes.img}
+            alt='이미지를 불러오지 못했습니다!'
+            onLoad={() => setIsLoaded(true)}
+            src={images[0].url}
+          />
+          {images.length > 1 && isLoaded && <Typography className={classes.photoText}>+{images.length - 1}</Typography>}
+        </Grid>
       )}
-    </Card>
+    </Grid>
   );
 };
 

--- a/front-end/legeno-around-here/src/components/PostItem.js
+++ b/front-end/legeno-around-here/src/components/PostItem.js
@@ -11,7 +11,7 @@ import LinesEllipsis from 'react-lines-ellipsis';
 
 const useStyles = makeStyles(() => ({
   root: {
-    borderBottom: '1px solid black',
+    borderBottom: '1.5px solid darkgray',
     marginTop: '5px',
   },
   cover: {

--- a/front-end/legeno-around-here/src/components/pages/post/PostReportSection.js
+++ b/front-end/legeno-around-here/src/components/pages/post/PostReportSection.js
@@ -19,9 +19,6 @@ import LinesEllipsis from 'react-lines-ellipsis';
 import Typography from '@material-ui/core/Typography';
 
 const useStyles = makeStyles((theme) => ({
-  center: {
-    textAlign: 'center',
-  },
   modal: {
     display: 'flex',
     alignItems: 'center',
@@ -109,13 +106,13 @@ const PostReportSection = ({ post }) => {
               <Loading />
             ) : (
               <>
+                <Typography color='textSecondary'>내용</Typography>
                 <Typography variant='subtitle1'>
-                  <div className={classes.center}>내용</div>
                   <LinesEllipsis text={post.writing} maxLine='2' ellipsis='...' trimRight basedOn='letters' />
                 </Typography>
+                <Typography color='textSecondary'>작성자</Typography>
                 <Typography variant='subtitle1'>
-                  <div className={classes.center}>작성자</div>
-                  <div className={classes.center}>{post.creator.nickname}</div>
+                  <div>{post.creator.nickname}</div>
                 </Typography>
                 <FormControl component='fieldset'>
                   <FormLabel component='legend'>사유선택</FormLabel>

--- a/front-end/legeno-around-here/src/components/pages/post/PostReportSection.js
+++ b/front-end/legeno-around-here/src/components/pages/post/PostReportSection.js
@@ -15,8 +15,13 @@ import Grid from '@material-ui/core/Grid';
 import { getAccessTokenFromCookie } from '../../../util/TokenUtils';
 import { createPostReport } from '../../api/API';
 import Loading from '../../Loading';
+import LinesEllipsis from 'react-lines-ellipsis';
+import Typography from '@material-ui/core/Typography';
 
 const useStyles = makeStyles((theme) => ({
+  center: {
+    textAlign: 'center',
+  },
   menuButton: {
     marginRight: theme.spacing(0),
   },
@@ -110,11 +115,19 @@ const PostReportSection = ({ post }) => {
               <Loading />
             ) : (
               <>
-                <h4>내 용 : {post.writing}</h4>
-                <h4>작성자 : {post.creator.nickname}</h4>
+                <Typography variant='subtitle1'>
+                  <div className={classes.center}>내용</div>
+                  <LinesEllipsis text={post.writing} maxLine='2' ellipsis='...' trimRight basedOn='letters' />
+                </Typography>
+                <Typography variant='subtitle1'>
+                  <div className={classes.center}>작성자</div>
+                  <div className={classes.center}>{post.creator.nickname}</div>
+                </Typography>
                 <FormControl component='fieldset'>
                   <FormLabel component='legend'>사유선택</FormLabel>
-                  <h5>여러 사유에 해당하는 경우, 대표적인 사유 1개를 선택해주세요!</h5>
+                  <Typography variant='subtitle2'>
+                    여러 사유에 해당하는 경우, 대표적인 사유 1개를 선택해주세요!
+                  </Typography>
                   <RadioGroup aria-label='gender' value={value} onChange={handleChange}>
                     {reportText.map((report) => (
                       <FormControlLabel key={report.id} value={report.value} control={<Radio />} label={report.value} />

--- a/front-end/legeno-around-here/src/components/pages/posting/PostingForm.js
+++ b/front-end/legeno-around-here/src/components/pages/posting/PostingForm.js
@@ -121,7 +121,7 @@ const PostingForm = () => {
           type='text'
           fullWidth
           id='standard-multiline-static'
-          label=''
+          helperText={`${writing.length}/2000`}
           multiline
           rows={10}
           placeholder='자신의 자랑을 입력해주세요!'

--- a/front-end/legeno-around-here/src/components/pages/posting/PostingUpdateForm.js
+++ b/front-end/legeno-around-here/src/components/pages/posting/PostingUpdateForm.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import Loading from '../../Loading';
 import { Typography } from '@material-ui/core';
 
-import { updatePost, findPost, savePostImages } from '../../api/API';
+import { findPost, savePostImages, updatePost } from '../../api/API';
 import { getAccessTokenFromCookie } from '../../../util/TokenUtils';
 import useStyles from '../posting/PostingFormStyles';
 import PostingFormImages from './PostingFormImages';
@@ -121,12 +121,14 @@ const PostingUpdateForm = ({ postId }) => {
         type='text'
         fullWidth
         id='standard-multiline-static'
-        label=''
+        helperText={`${writing.length}/2000`}
         multiline
-        rows={20}
+        rows={10}
         placeholder='자신의 자랑을 입력해주세요!'
         onChange={onWritingChanged}
         value={writing}
+        variant='outlined'
+        inputProps={{ maxLength: 2000 }}
       />
       {sectorName && <Typography className={classes.sector}>{sectorName}</Typography>}
       {areaName && <Typography className={classes.area}>{areaName}</Typography>}

--- a/front-end/legeno-around-here/src/components/pages/ranking/RankingItem.js
+++ b/front-end/legeno-around-here/src/components/pages/ranking/RankingItem.js
@@ -9,6 +9,7 @@ import FavoriteIcon from '@material-ui/icons/Favorite';
 import CommentIcon from '@material-ui/icons/Comment';
 import { convertDateFormat } from '../../../util/TimeUtils';
 import useStyle from './RankingItemStyle';
+import LinesEllipsis from 'react-lines-ellipsis';
 
 const FIRST_PRIZE_IMAGE_URL = '/images/gold.png';
 const SECOND_PRIZE_IMAGE_URL = '/images/silver.png';
@@ -34,26 +35,13 @@ const RankingItem = ({ post, rank, whetherToPrintZzangCount }) => {
   };
   const classes = useStyle(props);
 
-  const {
-    area,
-    commentsCount,
-    createdAt,
-    creator,
-    id,
-    zzang,
-    sector,
-    writing,
-  } = post;
+  const { area, commentsCount, createdAt, creator, id, zzang, sector, writing } = post;
 
   return (
-    <Card
-      className={classes.card}
-      data-id={id}
-      onClick={() => (document.location.href = `/posts/${id}`)}
-    >
+    <Card className={classes.card} data-id={id} onClick={() => (document.location.href = `/posts/${id}`)}>
       <div className={classes.rank}>
         {rank > 3 ? (
-          <Typography component="h5" variant="h5">
+          <Typography component='h5' variant='h5'>
             {rank}
           </Typography>
         ) : (
@@ -62,34 +50,25 @@ const RankingItem = ({ post, rank, whetherToPrintZzangCount }) => {
       </div>
       <div className={classes.details}>
         <CardContent className={classes.content}>
-          <Typography component="h6" variant="h5">
+          <Typography component='h6' variant='h5'>
             {sector.name} 부문
           </Typography>
-          <Typography variant="subtitle1" color="textSecondary">
+          <Typography variant='subtitle1' color='textSecondary'>
             {convertDateFormat(createdAt)}
           </Typography>
-          <Typography variant="subtitle1" color="textSecondary">
+          <Typography variant='subtitle1' color='textSecondary'>
             작성자 : {creator.nickname}
           </Typography>
-          <Typography variant="body2" color="textSecondary" component="p">
+          <Typography variant='body2' color='textSecondary'>
             작성 지역 : {area.fullName}
           </Typography>
-          <Typography
-            variant="body2"
-            color="textSecondary"
-            component="p"
-            className={classes.writing}
-          >
-            {writing}
+          <Typography variant='subtitle2' color='textSecondary' className={classes.writing}>
+            <LinesEllipsis text={writing} maxLine='3' ellipsis='...' trimRight basedOn='letters' />
           </Typography>
         </CardContent>
         <CardActions className={classes.reactions} disableSpacing>
           <IconButton className={classes.reactionIconSpace}>
-            {zzang.activated === true ? (
-              <FavoriteIcon className={classes.reactionIcon} />
-            ) : (
-              <FavoriteBorderIcon />
-            )}
+            {zzang.activated === true ? <FavoriteIcon className={classes.reactionIcon} /> : <FavoriteBorderIcon />}
             {zzang.count}
           </IconButton>
           <IconButton>

--- a/front-end/legeno-around-here/src/components/pages/sector/SectorItem.js
+++ b/front-end/legeno-around-here/src/components/pages/sector/SectorItem.js
@@ -9,7 +9,7 @@ const useStyles = makeStyles(() => ({
   text: {
     overflow: 'hidden',
     textOverflow: 'ellipsis',
-    width: '50%',
+    width: '55%',
   },
 }));
 

--- a/front-end/legeno-around-here/src/components/pages/sector/SectorItem.js
+++ b/front-end/legeno-around-here/src/components/pages/sector/SectorItem.js
@@ -1,20 +1,42 @@
 import React from 'react';
-import ListItem from '@material-ui/core/ListItem';
 import Divider from '@material-ui/core/Divider';
-import ListItemText from '@material-ui/core/ListItemText';
 import Typography from '@material-ui/core/Typography';
 import LinkWithoutStyle from '../../../util/LinkWithoutStyle';
+import { makeStyles } from '@material-ui/core/styles';
+import Grid from '@material-ui/core/Grid';
+
+const useStyles = makeStyles(() => ({
+  text: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    width: '50%',
+  },
+}));
 
 const SectorItem = ({ sector }) => {
+  const classes = useStyles();
+
   return (
     <>
       <LinkWithoutStyle to={'/sectors/' + sector.id}>
-        <ListItem alignItems='flex-start'>
-          <ListItemText primary={sector.name + ' 부문'} secondary={sector.description} />
-          <div>
-            <Typography variant='subtitle1'>{sector.creator.nickname} 만듦</Typography>
-          </div>
-        </ListItem>
+        <Grid container justify='space-between' alignItems='flex-start'>
+          <Grid item className={classes.text}>
+            <Typography noWrap variant='subtitle1'>
+              {sector.name + ' 부문'}
+            </Typography>
+            <Typography noWrap variant='subtitle2' color='textSecondary'>
+              {sector.description}
+            </Typography>
+          </Grid>
+          <Grid item>
+            <Typography noWrap variant='subtitle1' display='inline'>
+              {sector.creator.nickname}
+            </Typography>
+            <Typography noWrap variant='subtitle1' display='inline'>
+              {'만듦'}
+            </Typography>
+          </Grid>
+        </Grid>
         <Divider />
       </LinkWithoutStyle>
     </>

--- a/front-end/legeno-around-here/yarn.lock
+++ b/front-end/legeno-around-here/yarn.lock
@@ -9251,6 +9251,11 @@ react-is@^16.12.0, react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.0, react-i
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
+react-lines-ellipsis@^0.14.1:
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/react-lines-ellipsis/-/react-lines-ellipsis-0.14.1.tgz#dbc045b9c3bd0c46d2c1dee893d46e9260d53969"
+  integrity sha512-4nEDEzzfXy2bqRhLc00DWYb39FKIpGqaIIh/YT3KdHyM9pqD8cSfDSCdGy657sB12alCdT7cKK48Uk0OsRMvHQ==
+
 react-loading@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/react-loading/-/react-loading-2.0.3.tgz#e8138fb0c3e4674e481b320802ac7048ae14ffb9"


### PR DESCRIPTION
**이슈 번호**

resolved: #424
resolved: #412
resolved: #399

**작업 내용**

1. 홈 화면 글 내용 전반적으로 수정
2. 사진이 2개 이상일 때 (+1 같은 사진 위에 나오는 글씨가 정확히 중앙으로 오도록 수정
3. 사진이 2개 이상인데 이미지를 불러오지 못했을 때는 (+1 같은) 글씨가 나오지 않도록 기능 추가
4. 사진이 없을 때는 글 내용이 사진부분까지 보이도록 수정
5. 글 신고 모달 ellipsis 추가
6. Loading 컴포넌트 폰트 수정
7. 랭킹 페이지 ellipsis 추가
8. 부문명이 화면의 50%가 넘어가면 ellipsis 적용

<img width="379" alt="Screen Shot 2020-09-10 at 2 19 00 AM" src="https://user-images.githubusercontent.com/22311557/92639996-94889d80-f317-11ea-886c-b319d8f0b632.png">
<img width="378" alt="Screen Shot 2020-09-10 at 2 19 10 AM" src="https://user-images.githubusercontent.com/22311557/92640006-97838e00-f317-11ea-8fb8-730edd575129.png">
<img width="374" alt="Screen Shot 2020-09-10 at 3 49 34 AM" src="https://user-images.githubusercontent.com/22311557/92640724-adde1980-f318-11ea-9cea-d87f8dce9bbf.png">
<img width="383" alt="Screen Shot 2020-09-10 at 3 26 08 AM" src="https://user-images.githubusercontent.com/22311557/92640014-99e5e800-f317-11ea-9248-c843d161aa12.png">


**주의 사항**
1. 사진에도 보이지만 유저명이 길 경우에는 아래로 내려가게 됩니다. 현 상태에서 유저 명이 길 경우, 유저 명만 ...으로 나타내고 싶은데 쉽지 않네요 ㅠㅠ
2. 글 내용을 보여줄 때 누가 어디서 썼는지 나타내는 부분을 조금 바꿔봤습니다. 피드백 주시면 감사하겠습니당 :)