### PR TITLE
feat: 백엔드 cors 주소 / 프론드엔드 api 주소 환경마다 다르게 설정

### DIFF
--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/config/WebSecurityConfig.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/config/WebSecurityConfig.java
@@ -2,6 +2,8 @@ package wooteco.team.ittabi.legenoaroundhere.config;
 
 import java.util.Collections;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -18,6 +20,7 @@ import wooteco.team.ittabi.legenoaroundhere.infra.JwtTokenDecoder;
 
 @EnableWebSecurity
 @AllArgsConstructor
+@Slf4j
 public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final JwtTokenDecoder jwtTokenDecoder;
@@ -34,11 +37,13 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         return super.authenticationManagerBean();
     }
 
+    @Value("${cors.origin}")
     @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
+    public CorsConfigurationSource corsConfigurationSource(String corsOrigin) {
+        log.info("crossOrigin: {}", corsOrigin);
         CorsConfiguration configuration = new CorsConfiguration();
 
-        configuration.addAllowedOrigin("https://www.capzzang.co.kr");
+        configuration.addAllowedOrigin(corsOrigin);
         configuration.addAllowedHeader("*");
         configuration.addAllowedMethod("*");
         configuration.setAllowCredentials(true);

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/config/WebSecurityConfig.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/config/WebSecurityConfig.java
@@ -37,7 +37,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
         return super.authenticationManagerBean();
     }
 
-    @Value("${cors.origin}")
+    @Value("${security.cors.origin}")
     @Bean
     public CorsConfigurationSource corsConfigurationSource(String corsOrigin) {
         log.info("crossOrigin: {}", corsOrigin);

--- a/back-end/legeno-around-here/src/main/resources/application-local.properties
+++ b/back-end/legeno-around-here/src/main/resources/application-local.properties
@@ -27,3 +27,5 @@ spring.mail.username=
 spring.mail.password=
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+##################### CORS SETTING ############################
+cors.origin=http://localhost:3000

--- a/back-end/legeno-around-here/src/main/resources/application-local.properties
+++ b/back-end/legeno-around-here/src/main/resources/application-local.properties
@@ -28,4 +28,4 @@ spring.mail.password=
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 ##################### CORS SETTING ############################
-cors.origin=http://localhost:3000
+security.cors.origin=http://localhost:3000

--- a/back-end/legeno-around-here/src/test/resources/application.properties
+++ b/back-end/legeno-around-here/src/test/resources/application.properties
@@ -23,4 +23,4 @@ spring.mail.password=
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
 ##################### CORS SETTING ############################
-cors.origin=http://localhost:3000
+security.cors.origin=http://localhost:3000

--- a/back-end/legeno-around-here/src/test/resources/application.properties
+++ b/back-end/legeno-around-here/src/test/resources/application.properties
@@ -22,3 +22,5 @@ spring.mail.username=
 spring.mail.password=
 spring.mail.properties.mail.smtp.auth=true
 spring.mail.properties.mail.smtp.starttls.enable=true
+##################### CORS SETTING ############################
+cors.origin=http://localhost:3000

--- a/front-end/legeno-around-here/.env.development
+++ b/front-end/legeno-around-here/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API_SERVER_HOST=http://localhost:8080

--- a/front-end/legeno-around-here/.env.production
+++ b/front-end/legeno-around-here/.env.production
@@ -1,0 +1,1 @@
+REACT_APP_API_SERVER_HOST=https://back.capzzang.co.kr

--- a/front-end/legeno-around-here/src/components/api/API.js
+++ b/front-end/legeno-around-here/src/components/api/API.js
@@ -10,7 +10,7 @@ const DIRECTION_ASC = 'asc';
 const DEFAULT_SIZE = 10;
 const DEFAULT_SORTED_BY = 'id';
 const DEFAULT_DIRECTION = 'desc';
-const DEFAULT_URL = 'https://back.capzzang.co.kr';
+const DEFAULT_URL = `${process.env.REACT_APP_API_SERVER_HOST}`;
 
 export const loginUser = (email, password, handleReset) => {
   axios


### PR DESCRIPTION
**이슈 번호**

resolved: #437 

**작업 내용**

1. Backend
    - local: `http://localhost:3000`
    - product: `https://www.capzzang.co.kr`
2. Frontend API Host
    - local: `http://localhost:8080`
    - product: `https://back.capzzang.co.kr`
- 작업 상세 내용의 경우 이슈 참고

