### PR TITLE
feat: Admin Role을 가진 계정만 로그인 가능한 API 추가(For adminTool)

### DIFF
--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/adminController/UserAdminController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/adminController/UserAdminController.java
@@ -1,0 +1,30 @@
+package wooteco.team.ittabi.legenoaroundhere.adminController;
+
+import static wooteco.team.ittabi.legenoaroundhere.utils.UrlPathConstants.ADMIN_PATH;
+
+import lombok.AllArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import wooteco.team.ittabi.legenoaroundhere.dto.LoginRequest;
+import wooteco.team.ittabi.legenoaroundhere.dto.TokenResponse;
+import wooteco.team.ittabi.legenoaroundhere.service.UserService;
+
+@RestController
+@RequestMapping(ADMIN_PATH)
+@AllArgsConstructor
+public class UserAdminController {
+
+    private final UserService userService;
+
+    @PostMapping("/login")
+    public ResponseEntity<TokenResponse> adminLogin(@RequestBody LoginRequest loginRequest) {
+        TokenResponse token = userService.adminLogin(loginRequest);
+
+        return ResponseEntity
+            .ok(token);
+    }
+}

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/adminController/UserAdminController.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/adminController/UserAdminController.java
@@ -3,7 +3,6 @@ package wooteco.team.ittabi.legenoaroundhere.adminController;
 import static wooteco.team.ittabi.legenoaroundhere.utils.UrlPathConstants.ADMIN_PATH;
 
 import lombok.AllArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -21,8 +20,8 @@ public class UserAdminController {
     private final UserService userService;
 
     @PostMapping("/login")
-    public ResponseEntity<TokenResponse> adminLogin(@RequestBody LoginRequest loginRequest) {
-        TokenResponse token = userService.adminLogin(loginRequest);
+    public ResponseEntity<TokenResponse> loginAdmin(@RequestBody LoginRequest loginRequest) {
+        TokenResponse token = userService.loginAdmin(loginRequest);
 
         return ResponseEntity
             .ok(token);

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/config/WebSecurityConfig.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/config/WebSecurityConfig.java
@@ -62,14 +62,15 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             .and()
             .authorizeRequests()
-            .antMatchers("/h2-console/**").permitAll()
             .antMatchers(
+                "/h2-console/**",
                 "/v2/api-docs",
                 "/swagger-resources/**",
                 "/swagger-ui.html",
                 "/webjars/**",
                 "/check-joined",
                 "/join",
+                "/admin/login",
                 "/login",
                 "/mail-auth/**",
                 "/profile").permitAll()

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/User.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/User.java
@@ -129,6 +129,10 @@ public class User extends BaseEntity implements UserDetails {
         return sectorCreatorAwards.size();
     }
 
+    public boolean hasNotRole(Role role) {
+        return !this.roles.contains(role.getRoleName());
+    }
+
     @Override
     public String getUsername() {
         return this.email.getEmail();
@@ -180,5 +184,4 @@ public class User extends BaseEntity implements UserDetails {
     public void setArea(Area area) {
         this.area = area;
     }
-
 }

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/UserService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/UserService.java
@@ -29,6 +29,7 @@ import wooteco.team.ittabi.legenoaroundhere.dto.UserPasswordUpdateRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserUpdateRequest;
 import wooteco.team.ittabi.legenoaroundhere.exception.AlreadyExistUserException;
+import wooteco.team.ittabi.legenoaroundhere.exception.NotAuthorizedException;
 import wooteco.team.ittabi.legenoaroundhere.exception.NotExistsException;
 import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 import wooteco.team.ittabi.legenoaroundhere.infra.JwtTokenGenerator;
@@ -86,7 +87,7 @@ public class UserService implements UserDetailsService {
     }
 
     @Transactional
-    public TokenResponse adminLogin(LoginRequest loginRequest) {
+    public TokenResponse loginAdmin(LoginRequest loginRequest) {
         User user = findUserByEmail(loginRequest);
 
         validateAdmin(user);
@@ -106,7 +107,7 @@ public class UserService implements UserDetailsService {
 
     private void validateAdmin(User user) {
         if (user.hasNotRole(Role.ADMIN)) {
-            throw new NotExistsException("가입되지 않은 관리자입니다.");
+            throw new NotAuthorizedException("관리자가 아닙니다.");
         }
     }
 

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/UserService.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/service/UserService.java
@@ -89,7 +89,6 @@ public class UserService implements UserDetailsService {
     @Transactional
     public TokenResponse loginAdmin(LoginRequest loginRequest) {
         User user = findUserByEmail(loginRequest);
-
         validateAdmin(user);
         return getTokenResponse(loginRequest, user);
     }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/UserAcceptanceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/acceptance/UserAcceptanceTest.java
@@ -9,6 +9,8 @@ import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.AreaConstants.TEST_AUTH_NUMBER;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.ImageConstants.TEST_IMAGE_DIR;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.ImageConstants.TEST_IMAGE_NAME;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_ADMIN_EMAIL;
+import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_ADMIN_PASSWORD;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_NEW_USER_EMAIL;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_NEW_USER_NICKNAME;
 import static wooteco.team.ittabi.legenoaroundhere.utils.constants.UserConstants.TEST_NEW_USER_PASSWORD;
@@ -180,6 +182,25 @@ public class UserAcceptanceTest extends AcceptanceTest {
         assertThat(userOtherResponse.getImage());
     }
 
+    /**
+     * Feature: 관리자 로그인 Scenario: 관리자 로그인을 한다.
+     * <p>
+     * When 관리자가 관리자 로그인을 한다. Then 로그인이 되었다.
+     * <p>
+     * When 사용자가 관리자 로그인을 한다. Then 로그인에 실패하였다.
+     * <p>
+     */
+    @DisplayName("어드민 로그인을 진행한다.")
+    @Test
+    void loginAdmin() {
+        TokenResponse tokenResponse = adminLogin(TEST_ADMIN_EMAIL, TEST_ADMIN_PASSWORD);
+        String accessToken = tokenResponse.getAccessToken();
+        assertThat(tokenResponse).isNotNull();
+        assertThat(accessToken).hasSizeGreaterThanOrEqualTo(TOKEN_MIN_SIZE);
+
+        assertThatThrownBy(() -> adminLogin(TEST_USER_EMAIL, TEST_USER_PASSWORD));
+    }
+
     private String createUserWithoutArea(String email, String nickname, String password) {
         Map<String, String> params = new HashMap<>();
         params.put("email", email);
@@ -315,5 +336,22 @@ public class UserAcceptanceTest extends AcceptanceTest {
             .then()
             .statusCode(HttpStatus.OK.value())
             .extract().as(UserOtherResponse.class);
+    }
+
+    private TokenResponse adminLogin(String email, String password) {
+        Map<String, String> params = new HashMap<>();
+        params.put("email", email);
+        params.put("password", password);
+
+        return given()
+            .body(params)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .when()
+            .post("/admin/login")
+            .then()
+            .log().all()
+            .statusCode(HttpStatus.OK.value())
+            .extract().as(TokenResponse.class);
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/service/UserServiceTest.java
@@ -44,6 +44,7 @@ import wooteco.team.ittabi.legenoaroundhere.dto.UserPasswordUpdateRequest;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserResponse;
 import wooteco.team.ittabi.legenoaroundhere.dto.UserUpdateRequest;
 import wooteco.team.ittabi.legenoaroundhere.exception.AlreadyExistUserException;
+import wooteco.team.ittabi.legenoaroundhere.exception.NotAuthorizedException;
 import wooteco.team.ittabi.legenoaroundhere.exception.NotExistsException;
 import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 import wooteco.team.ittabi.legenoaroundhere.repository.MailAuthRepository;
@@ -303,7 +304,7 @@ class UserServiceTest extends ServiceTest {
         assertThat(user.hasNotRole(Role.ADMIN)).isFalse();
 
         LoginRequest loginRequest = new LoginRequest(adminUser, TEST_ADMIN_PASSWORD);
-        TokenResponse response = userService.login(loginRequest);
+        TokenResponse response = userService.loginAdmin(loginRequest);
         assertThat(response.getAccessToken()).isNotEmpty();
         assertThat(response.getAccessToken()).hasSizeGreaterThan(TOKEN_MIN_SIZE);
     }
@@ -317,8 +318,7 @@ class UserServiceTest extends ServiceTest {
         assertThat(user.hasNotRole(Role.ADMIN)).isTrue();
 
         LoginRequest loginRequest = new LoginRequest(notAdminUser, TEST_USER_PASSWORD);
-        TokenResponse response = userService.login(loginRequest);
-        assertThat(response.getAccessToken()).isNotEmpty();
-        assertThat(response.getAccessToken()).hasSizeGreaterThan(TOKEN_MIN_SIZE);
+        assertThatThrownBy(() -> userService.loginAdmin(loginRequest))
+            .isInstanceOf(NotAuthorizedException.class);
     }
 }


### PR DESCRIPTION
**이슈 번호**

resolved: #445

**작업 내용**

1. Admin Role을 가진 계정만 로그인 가능한 API 추가(For adminTool)

**테스트 작성 여부**

- [X] Test case

**주의 사항**
