### PR TITLE
feat: 비밀번호 찾기 페이지 및 API 구현 [ISSUE-465]

### DIFF
--- a/front-end/legeno-around-here/src/App.js
+++ b/front-end/legeno-around-here/src/App.js
@@ -5,12 +5,14 @@ import Login from './components/pages/LoginPage';
 import PostingPage from './components/pages/posting/PostingPage';
 import SectorPage from './components/pages/sector/SectorPage';
 import PostDetailPage from './components/pages/post/PostDetailPage';
-import MyProfileEditPage from './components/pages/myProfileEdit/MyProfileEditPage';
+import MyProfileEditPage
+  from './components/pages/myProfileEdit/MyProfileEditPage';
 import PostingUpdatePage from './components/pages/posting/PostingUpdatePage';
 import MyProfilePage from './components/pages/myProfile/MyProfilePage';
 import RankingPage from './components/pages/ranking/RankingPage';
 import RankingPageReload from './components/pages/ranking/RankingPageReload';
-import OthersProfilePage from './components/pages/OthersProfile/OthersProfilePage';
+import OthersProfilePage
+  from './components/pages/OthersProfile/OthersProfilePage';
 import MyPosts from './components/pages/myProfile/MyPosts';
 import HomePage from './components/pages/home/HomePage';
 import HomePageReload from './components/pages/home/HomePageReload';
@@ -21,7 +23,9 @@ import ErrorPage from './components/pages/ErrorPage';
 import MyAwardPage from './components/pages/myAward/MyAwardPage';
 import OtherAwardPage from './components/pages/OtherAward/OtherAwardPage';
 import SectorDetailPage from './components/pages/sector/SectorDetailPage';
-import WithdrawConfirmPage from './components/pages/myProfile/WithdrawConfirmPage';
+import WithdrawConfirmPage
+  from './components/pages/myProfile/WithdrawConfirmPage';
+import FindPasswordPage from './components/pages/find/FindPasswordPage';
 
 function App() {
   const mainArea = localStorage.getItem('mainAreaName');
@@ -39,6 +43,7 @@ function App() {
         <Route path='/home-reload' exact component={HomePageReload} />
         <Route path='/join' exact component={Join} />
         <Route path='/login' exact component={Login} />
+        <Route path='/find/password' exact component={FindPasswordPage} />
         <Route path='/users/me' exact component={MyProfilePage} />
         <Route path='/posting' exact component={PostingPage} />
         <Route path='/posts/:postId/update' exact component={PostingUpdatePage} />

--- a/front-end/legeno-around-here/src/components/api/API.js
+++ b/front-end/legeno-around-here/src/components/api/API.js
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import {
   removeAccessTokenCookie,
-  setAccessTokenCookie
+  setAccessTokenCookie,
 } from '../../util/TokenUtils';
 
 const HTTP_STATUS_OK = 200;
@@ -31,6 +31,24 @@ export const loginUser = (email, password, handleReset, history) => {
       alert(errorResponse.errorMessage);
       handleReset();
     });
+};
+
+export const findPassword = async (nickname, email, handleReset, history) => {
+  try {
+    const response = await axios.post(DEFAULT_URL + '/find/password', {
+      nickname,
+      email,
+    });
+    if (response.status === HTTP_STATUS_OK) {
+      alert('이메일로 변경된 비밀번호를 전송했습니다! 로그인 후 비밀번호를 수정해주세요!');
+      history.push('/login');
+    }
+  } catch (error) {
+    if (await redirectLoginWhenUnauthorized(error, history)) return;
+    console.log(error);
+    const errorResponse = error.response.data;
+    alert(errorResponse.errorMessage);
+  }
 };
 
 export const savePostImages = async (formData, accessToken, history) => {
@@ -471,7 +489,8 @@ export const findAllSimpleSectors = async (accessToken, history) => {
       'X-Auth-Token': accessToken,
     },
   };
-  return await axios.get(DEFAULT_URL + `/sectors/simple`, config)
+  return await axios
+    .get(DEFAULT_URL + `/sectors/simple`, config)
     .then((response) => {
       return response.data;
     })
@@ -588,7 +607,7 @@ export const findOthersProfileById = async ({ accessToken, userId, history }) =>
       if (await redirectLoginWhenUnauthorized(error, history)) return;
 
       if (error.response && error.response.status === 404) {
-        alert("존재하지 않는 회원입니다.");
+        alert('존재하지 않는 회원입니다.');
         history.goBack();
         return;
       }
@@ -705,18 +724,18 @@ export const withdraw = (accessToken, history) => {
     },
   };
   axios
-  .delete(DEFAULT_URL + '/users/me', config)
-  .then(async () => {
-    await removeAccessTokenCookie();
-    alert('탈퇴 완료되었습니다. 그동안 이용해주셔서 감사합니다!');
-    history.push('/');
-  })
-  .catch(async (error) => {
-    if (await redirectLoginWhenUnauthorized(error)) return;
+    .delete(DEFAULT_URL + '/users/me', config)
+    .then(async () => {
+      await removeAccessTokenCookie();
+      alert('탈퇴 완료되었습니다. 그동안 이용해주셔서 감사합니다!');
+      history.push('/');
+    })
+    .catch(async (error) => {
+      if (await redirectLoginWhenUnauthorized(error)) return;
 
-    const errorResponse = error.response.data;
-    alert(errorResponse.errorMessage);
-  });
+      const errorResponse = error.response.data;
+      alert(errorResponse.errorMessage);
+    });
 };
 
 // 로그인 페이지로 리다이렉트 될 경우 true 반환, 그렇지 않을 경우 false 반환

--- a/front-end/legeno-around-here/src/components/pages/find/FindPasswordPage.js
+++ b/front-end/legeno-around-here/src/components/pages/find/FindPasswordPage.js
@@ -1,18 +1,18 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { loginUser } from '../api/API';
+import React, { useEffect, useState } from 'react';
 
 import Avatar from '@material-ui/core/Avatar';
 import Button from '@material-ui/core/Button';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import TextField from '@material-ui/core/TextField';
-import Grid from '@material-ui/core/Grid';
 import Box from '@material-ui/core/Box';
 import ThumbUpIcon from '@material-ui/icons/ThumbUp';
 import Typography from '@material-ui/core/Typography';
 import { makeStyles } from '@material-ui/core/styles';
 import Container from '@material-ui/core/Container';
-import { removeAccessTokenCookie } from '../../util/TokenUtils';
-import LinkWithoutStyle from '../../util/LinkWithoutStyle';
+import { findPassword } from '../../api/API';
+import { removeAccessTokenCookie } from '../../../util/TokenUtils';
+import Grid from '@material-ui/core/Grid';
+import LinkWithoutStyle from '../../../util/LinkWithoutStyle';
 
 const Copyright = () => {
   return (
@@ -42,35 +42,28 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const LoginForm = ({ history }) => {
+const FindPasswordPage = ({ history }) => {
   const classes = useStyles();
+  const [nickname, setNickname] = useState('');
   const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
 
-  const handleChangeEmail = useCallback(({ target: { value } }) => {
+  const handleChangeNickname = ({ target: { value } }) => {
+    setNickname(value);
+  };
+
+  const handleChangeEmail = ({ target: { value } }) => {
     setEmail(value);
-  }, []);
+  };
 
-  const handleChangePassword = useCallback(({ target: { value } }) => {
-    setPassword(value);
-  }, []);
-
-  const handleReset = useCallback(() => {
+  const handleReset = () => {
+    setNickname('');
     setEmail('');
-    setPassword('');
-  }, []);
+  };
 
-  const login = useCallback(() => {
-    loginUser(email, password, handleReset, history);
-  }, [email, password, handleReset, history]);
-
-  const handleSubmit = useCallback(
-    (event) => {
-      event.preventDefault();
-      login();
-    },
-    [login],
-  );
+  const submit = (event) => {
+    event.preventDefault();
+    findPassword(nickname, email, handleReset, history);
+  };
 
   useEffect(() => {
     removeAccessTokenCookie();
@@ -84,9 +77,22 @@ const LoginForm = ({ history }) => {
           <ThumbUpIcon />
         </Avatar>
         <Typography component='h1' variant='h5'>
-          우리동네캡짱 로그인
+          우리동네캡짱 비밀번호 찾기
         </Typography>
-        <form onSubmit={handleSubmit} className={classes.form}>
+        <form onSubmit={submit} className={classes.form}>
+          <TextField
+            variant='outlined'
+            margin='normal'
+            required
+            fullWidth
+            name='nickname'
+            label='닉네임'
+            type='text'
+            id='nickname'
+            autoComplete='current-password'
+            value={nickname}
+            onChange={handleChangeNickname}
+          />
           <TextField
             variant='outlined'
             margin='normal'
@@ -101,31 +107,13 @@ const LoginForm = ({ history }) => {
             value={email}
             onChange={handleChangeEmail}
           />
-          <TextField
-            variant='outlined'
-            margin='normal'
-            required
-            fullWidth
-            name='password'
-            label='비밀번호'
-            type='password'
-            id='password'
-            autoComplete='current-password'
-            value={password}
-            onChange={handleChangePassword}
-          />
           <Button type='submit' fullWidth variant='contained' color='primary' className={classes.submit}>
-            로그인
+            재설정 메일 발송
           </Button>
-          <Grid container justify='space-between'>
+          <Grid container direction='row-reverse' justify='space-between'>
             <Grid item>
-              <LinkWithoutStyle to='/join' variant='body2'>
-                {'처음이신가요? 회원가입을 해주세요!'}
-              </LinkWithoutStyle>
-            </Grid>
-            <Grid item>
-              <LinkWithoutStyle to='/find/password' variant='body2'>
-                {'비밀번호를 까먹으셨나요?'}
+              <LinkWithoutStyle to='/login' variant='body2'>
+                {'뒤로 가기'}
               </LinkWithoutStyle>
             </Grid>
           </Grid>
@@ -138,4 +126,4 @@ const LoginForm = ({ history }) => {
   );
 };
 
-export default LoginForm;
+export default FindPasswordPage;


### PR DESCRIPTION
**이슈 번호**

resolved: #465 

**작업 내용**

1. 비밀번호 찾기 페이지 및 API 구현
2. 로그인 페이지에 비밀번호 찾기 Link
3. 로그인 페이지 validate 활성화

<img width="382" alt="Screen Shot 2020-09-23 at 3 05 22 AM" src="https://user-images.githubusercontent.com/22311557/93921340-5fcf0a00-fd4b-11ea-9a81-97b9747313a5.png">
<img width="383" alt="Screen Shot 2020-09-23 at 3 11 23 AM" src="https://user-images.githubusercontent.com/22311557/93921346-62316400-fd4b-11ea-812e-ed85a026ce23.png">

