### PR TITLE
fix: 302 응답에 대한 redirect 요청에서 에러가 나는 문제 해결시도

### DIFF
--- a/front-end/legeno-around-here/src/components/api/API.js
+++ b/front-end/legeno-around-here/src/components/api/API.js
@@ -741,6 +741,10 @@ const redirectLoginWhenUnauthorized = (error, history) => {
   if (error.response && error.response.status === 403) {
     history.push('/login');
     return true;
+  } else if (error.response && error.response.status === 302) {
+    removeAccessTokenCookie();
+    history.push('/login');
+    return true;
   } else if (error.response && error.response.status === 500) {
     return false;
   }


### PR DESCRIPTION
**이슈 번호**

resolved: #486 

**작업 내용**

1. 302 응답을 잡아서 리다이렉트시키는 자바스크립트 코드를 추가함

**테스트 작성 여부**

- [ ] Test case

**주의 사항**
로컬에서 테스트해볼 수 없는 코드였음
(로컬에서는 https 요청 안보냈다고 302응답 하지 않기 때문)
따라서 문제가 해결되지 않았을 수 있음.