### PR TITLE
fix: 글 상세에서 사진이 잘리는 버그 수정

### DIFF
--- a/front-end/legeno-around-here/src/components/pages/post/PostImageItem.js
+++ b/front-end/legeno-around-here/src/components/pages/post/PostImageItem.js
@@ -6,6 +6,7 @@ const useStyles = makeStyles(() => ({
     width: 'auto',
     height: 'auto',
     maxHeight: '400px',
+    maxWidth: '-webkit-fill-available',
     backgroundSize: 'contain',
   },
 }));


### PR DESCRIPTION
**이슈 번호**

resolved: #493 

**작업 내용**

1. 글 상세에서 사진이 잘리는 버그 수정

<img width="377" alt="Screen Shot 2020-09-30 at 12 54 37 AM" src="https://user-images.githubusercontent.com/22311557/94582803-a5458700-02b7-11eb-91fb-f3c9d8e185ca.png">
