### PR TITLE
refactor: 댓글, 글, 부문 삭제시 해당하는 알림도 삭제되도록 설정

### DIFF
--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/comment/Comment.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/comment/Comment.java
@@ -25,6 +25,7 @@ import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import wooteco.team.ittabi.legenoaroundhere.domain.BaseEntity;
 import wooteco.team.ittabi.legenoaroundhere.domain.State;
+import wooteco.team.ittabi.legenoaroundhere.domain.notification.Notification;
 import wooteco.team.ittabi.legenoaroundhere.domain.post.Post;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 import wooteco.team.ittabi.legenoaroundhere.exception.NotAvailableException;
@@ -33,7 +34,7 @@ import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@ToString(exclude = {"post", "superComment", "cocomments", "zzangs"})
+@ToString(exclude = {"post", "superComment", "cocomments", "zzangs", "notifications"})
 @SQLDelete(sql = "UPDATE comment SET deleted_at = NOW() WHERE id = ?")
 @Where(clause = "deleted_at IS NULL")
 public class Comment extends BaseEntity {
@@ -65,6 +66,9 @@ public class Comment extends BaseEntity {
 
     @OneToMany(mappedBy = "comment", cascade = CascadeType.PERSIST, orphanRemoval = true)
     private List<CommentZzang> zzangs = new ArrayList<>();
+
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Notification> notifications = new ArrayList<>();
 
     public Comment(User creator, String writing) {
         validateLength(writing);

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/post/Post.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/post/Post.java
@@ -25,6 +25,7 @@ import wooteco.team.ittabi.legenoaroundhere.domain.BaseEntity;
 import wooteco.team.ittabi.legenoaroundhere.domain.State;
 import wooteco.team.ittabi.legenoaroundhere.domain.area.Area;
 import wooteco.team.ittabi.legenoaroundhere.domain.comment.Comment;
+import wooteco.team.ittabi.legenoaroundhere.domain.notification.Notification;
 import wooteco.team.ittabi.legenoaroundhere.domain.post.image.PostImage;
 import wooteco.team.ittabi.legenoaroundhere.domain.sector.Sector;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
@@ -35,7 +36,7 @@ import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@ToString(exclude = {"comments", "postImages", "zzangs"})
+@ToString(exclude = {"comments", "postImages", "zzangs", "notifications"})
 @SQLDelete(sql = "UPDATE post SET deleted_at = NOW() WHERE id = ?")
 @Where(clause = "deleted_at IS NULL")
 public class Post extends BaseEntity {
@@ -71,6 +72,9 @@ public class Post extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "creator_id")
     private User creator;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Notification> notifications = new ArrayList<>();
 
     @Builder
     public Post(String writing, List<PostImage> postImages, Area area, Sector sector,

--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/sector/Sector.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/sector/Sector.java
@@ -21,13 +21,14 @@ import lombok.ToString;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 import wooteco.team.ittabi.legenoaroundhere.domain.BaseEntity;
+import wooteco.team.ittabi.legenoaroundhere.domain.notification.Notification;
 import wooteco.team.ittabi.legenoaroundhere.domain.post.Post;
 import wooteco.team.ittabi.legenoaroundhere.domain.user.User;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@ToString(exclude = {"posts"})
+@ToString(exclude = {"posts", "notifications"})
 @SQLDelete(sql = "UPDATE sector SET deleted_at = NOW() WHERE id = ?")
 @Where(clause = "deleted_at IS NULL")
 public class Sector extends BaseEntity {
@@ -57,6 +58,9 @@ public class Sector extends BaseEntity {
     @ManyToOne
     @JoinColumn(name = "last_modifier_id", nullable = false)
     private User lastModifier;
+
+    @OneToMany(mappedBy = "sector", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Notification> notifications = new ArrayList<>();
 
     @Builder
     public Sector(String name, String description, User creator, User lastModifier,


### PR DESCRIPTION
**이슈 번호**

resolved: #500 

**작업 내용**

1. 댓글, 글, 부문 삭제시 해당하는 알림도 삭제되도록 설정

**테스트 작성 여부**

- 따로 메서드는 작성하지 않아서 테스트는 작성하지 않았습니다.
- 로컬에서 테스트는 완료되었습니다.