### PR TITLE
feat: 테스트 커버리지 도구 Jacoco 적용

### DIFF
--- a/back-end/legeno-around-here/build.gradle
+++ b/back-end/legeno-around-here/build.gradle
@@ -2,11 +2,68 @@ plugins {
     id 'org.springframework.boot' version '2.3.1.RELEASE'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
     id 'java'
+    id 'jacoco'
 }
 
 group = 'wooteco.team.ittabi'
 version = '0.0.1-SNAPSHOT'
 sourceCompatibility = '1.8'
+
+jacoco {
+    toolVersion = '0.8.5'
+}
+
+jacocoTestReport {
+    reports {
+        html.enabled true
+        xml.enabled false
+        csv.enabled false
+    }
+
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            enabled = true
+            element = 'BUNDLE'
+
+            limit {
+                counter = 'INSTRUCTION'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.70
+            }
+
+            excludes = []
+        }
+
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.50
+            }
+
+            excludes = [
+                    '*.mailauth.*',
+                    '*.config.*',
+                    '*.MailAuthService',
+                    '*.aws.*',
+                    'wooteco.team.ittabi.legenoaroundhere.domain.award.PopularityPostCreatorAward',
+            ]
+        }
+    }
+}
 
 repositories {
     mavenCentral()
@@ -46,4 +103,5 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
 }

--- a/back-end/legeno-around-here/lombok.config
+++ b/back-end/legeno-around-here/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true


### PR DESCRIPTION
**이슈 번호**

resolved: #506 

**작업 내용**

1. 테스트 커버리지 도구 Jacoco 적용
2. Jacoco 테스트에서 Lombok 어노테이션 적용하지 않도록 lombok.config 추가

**주의 사항**

- BUNDLE 단위의 INSTRUCTION 커버리지가 80%, BRANCH 커버리지가 70%가 넘으면 통과되도록 해놓았습니다. BRANCH도 80%를 넘겨야 하기에 테스트코드를 추가하고 BRANCH를 80%로 수정해야될 것 같습니다 :)
- CLASS 단위의 BRANCH 커버리지가 80%를 넘기지 못하는 게 많습니다. config나 mailauth와 같이 테스트하지 못하는 부분은 제외해놓은 상태며 커버리지가 너무 낮은 클래스도 제외해놓았습니다. 지금은 BRANCH 커버리지를 50%로 조정해서 테스트를 통과시키도록 해놓았습니다. 테스트 코드를 추가하고 난 뒤 BRANCH 커버리지를 80%로 수정해야될 것 같습니다. 
- 읽으시면서 이해가 잘 안 가시는 부분도 있을텐데 노션으로 정리해서 공유하겠습니다!
