### PR TITLE
refactor: 닉네임 규칙 변경 [ISSUE-522]

### DIFF
--- a/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/Nickname.java
+++ b/back-end/legeno-around-here/src/main/java/wooteco/team/ittabi/legenoaroundhere/domain/user/Nickname.java
@@ -1,5 +1,7 @@
 package wooteco.team.ittabi.legenoaroundhere.domain.user;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
@@ -19,7 +21,9 @@ import wooteco.team.ittabi.legenoaroundhere.exception.WrongUserInputException;
 @ToString
 public class Nickname {
 
-    private static final int MAX_LENGTH = 10;
+    private static final int MAX_LENGTH = 30;
+    private static final List<String> FORBIDDEN_SUBSTRINGS = Arrays.asList(
+        "&", "=", "_", "\'", "-", "+", ",", "<", ">", "..");
 
     @Column(nullable = false)
     private String nickname;
@@ -32,8 +36,8 @@ public class Nickname {
     private void validate(String nickname) {
         validateNull(nickname);
         validateEmpty(nickname);
-        validateSpace(nickname);
         validateLength(nickname);
+        validateContainForbiddenStrings(nickname);
     }
 
     private void validateNull(String nickname) {
@@ -48,15 +52,22 @@ public class Nickname {
         }
     }
 
-    private void validateSpace(String nickname) {
-        if (nickname.contains(" ")) {
-            throw new WrongUserInputException("닉네임은 공백을 포함할 수 없습니다.");
-        }
-    }
-
     private void validateLength(String nickname) {
         if (nickname.length() > MAX_LENGTH) {
             throw new WrongUserInputException("닉네임은 " + MAX_LENGTH + "글자 이하여야 합니다.");
+        }
+    }
+
+    private void validateContainForbiddenStrings(String nickname) {
+        for (String forbiddenSubstring : FORBIDDEN_SUBSTRINGS) {
+            validateContainForbiddenString(nickname, forbiddenSubstring);
+        }
+    }
+
+    private void validateContainForbiddenString(String nickname, String forbiddenSubstring) {
+        if (nickname.contains(forbiddenSubstring)) {
+            throw new WrongUserInputException(
+                "닉네임은 " + forbiddenSubstring + "을 포함할 수 없습니다.");
         }
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/user/NicknameTest.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/domain/user/NicknameTest.java
@@ -34,19 +34,18 @@ class NicknameTest {
     }
 
     @ParameterizedTest
-    @DisplayName("생성자 테스트 - 닉네임에 공백이 포함되었을 때")
-    @ValueSource(strings = {" ", "a ", " a", "a a"})
+    @DisplayName("생성자 테스트 - 닉네임에 사용할 수 없는 특수문자가 포함되었을 때")
+    @ValueSource(strings = {"&히", "히=히", "히히_", "히히\'", "히-히", "히+히", ",", "<", ">", ".."})
     void constructor_IfExistSpace_ThrowException(String input) {
         assertThatThrownBy(() -> new Nickname(input))
-            .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("닉네임은 공백을 포함할 수 없습니다.");
+            .isInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    @DisplayName("생성자 테스트 - 닉네임이 10글자를 초과했을 때")
+    @DisplayName("생성자 테스트 - 닉네임이 30글자를 초과했을 때")
     void constructor_IfLengthIsMoreThanMaximum_ThrowException() {
-        assertThatThrownBy(() -> new Nickname("이글자는열한글자입니다"))
+        assertThatThrownBy(() -> new Nickname("1234567890123456789012345678901"))
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("닉네임은 10글자 이하여야 합니다.");
+            .hasMessage("닉네임은 30글자 이하여야 합니다.");
     }
 }

--- a/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/utils/constants/UserConstants.java
+++ b/back-end/legeno-around-here/src/test/java/wooteco/team/ittabi/legenoaroundhere/utils/constants/UserConstants.java
@@ -18,7 +18,7 @@ public class UserConstants {
     public static final String TEST_USER_OTHER_PASSWORD = "Password";
 
     public static final String TEST_NEW_USER_EMAIL = "n_user@test.com";
-    public static final String TEST_NEW_USER_NICKNAME = "n_userName";
+    public static final String TEST_NEW_USER_NICKNAME = "nUserName";
     public static final String TEST_NEW_USER_PASSWORD = "n_userPassword";
 
     public static final Long TEST_THE_OTHER_USER_ID = 4L;


### PR DESCRIPTION
구글의 닉네임 규칙을 따르도록 수정
 - 띄어쓰기 허용
 - 글자수 1 ~ 30자
 - 구글에서 금지하는 특수문자 금지

**이슈 번호**

resolved: #522 

**작업 내용**

1. 닉네임 규칙 변경

**테스트 작성 여부**

- [X] Test case

**주의 사항**
